### PR TITLE
feat: add gpt-5.3-codex-spark, web search annotations, integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,19 +148,23 @@ curl http://127.0.0.1:8000/v1/chat/completions \
 
 ## Supported Models
 
-| Model | Reasoning Efforts |
-|-------|-------------------|
-| `gpt-5` | `minimal` / `low` / `medium` / `high` |
-| `gpt-5.1` | `low` / `medium` / `high` |
-| `gpt-5.2` | `low` / `medium` / `high` / `xhigh` |
-| `gpt-5-codex` | `low` / `medium` / `high` |
-| `gpt-5.1-codex` | `low` / `medium` / `high` |
-| `gpt-5.1-codex-max` | `low` / `medium` / `high` / `xhigh` |
-| `gpt-5.1-codex-mini` | `low` / `medium` / `high` |
-| `gpt-5.2-codex` | `low` / `medium` / `high` / `xhigh` |
-| `gpt-5.3-codex` | `low` / `medium` / `high` / `xhigh` |
-| `codex-mini` | `low` / `medium` / `high` |
+| Model | Reasoning Efforts | Status |
+|-------|-------------------|--------|
+| `gpt-5` | `minimal` / `low` / `medium` / `high` | ✅ Supported |
+| `gpt-5.1` | `low` / `medium` / `high` | ✅ Supported |
+| `gpt-5.2` | `low` / `medium` / `high` / `xhigh` | ✅ Supported |
+| `gpt-5-codex` | `low` / `medium` / `high` | ✅ Supported |
+| `gpt-5.1-codex` | `low` / `medium` / `high` | ✅ Supported |
+| `gpt-5.1-codex-max` | `low` / `medium` / `high` / `xhigh` | ✅ Supported |
+| `gpt-5.2-codex` | `low` / `medium` / `high` / `xhigh` | ✅ Supported |
+| `gpt-5.3-codex` | `low` / `medium` / `high` / `xhigh` | ✅ Supported |
+| `gpt-5.3-codex-spark` | `low` / `medium` / `high` / `xhigh` | ✅ Supported |
 
+### Deprecated / Unsupported Models
+
+| Model | Reason |
+|-------|--------|
+| `codex-mini` / `gpt-5.1-codex-mini` | ❌ Discontinued by upstream — removed |
 ---
 
 ## API Endpoints
@@ -313,13 +317,15 @@ curl http://127.0.0.1:8000/v1/chat/completions \
 - `gpt-5.1`
 - `gpt-5.2`
 - `gpt-5-codex`
-- `gpt-5.2-codex`
 - `gpt-5.1-codex`
 - `gpt-5.1-codex-max`
-- `gpt-5.1-codex-mini`
+- `gpt-5.2-codex`
 - `gpt-5.3-codex`
-- `codex-mini`
+- `gpt-5.3-codex-spark`
 
+### Deprecated
+
+- ~~`codex-mini` / `gpt-5.1-codex-mini`~~ — discontinued by upstream
 # Customisation / Configuration
 
 ### Thinking effort

--- a/gptmock/services/model_registry.py
+++ b/gptmock/services/model_registry.py
@@ -40,15 +40,14 @@ def normalize_model_name(name: str | None, debug_model: str | None = None) -> st
         "gpt5.3-codex": "gpt-5.3-codex",
         "gpt-5.3-codex": "gpt-5.3-codex",
         "gpt-5.3-codex-latest": "gpt-5.3-codex",
+        "gpt5.3-codex-spark": "gpt-5.3-codex-spark",
+        "gpt-5.3-codex-spark": "gpt-5.3-codex-spark",
+        "gpt-5.3-codex-spark-latest": "gpt-5.3-codex-spark",
         "gpt5-codex": "gpt-5-codex",
         "gpt-5-codex": "gpt-5-codex",
         "gpt-5-codex-latest": "gpt-5-codex",
         "gpt-5.1-codex": "gpt-5.1-codex",
         "gpt-5.1-codex-max": "gpt-5.1-codex-max",
-        "codex": "codex-mini-latest",
-        "codex-mini": "codex-mini-latest",
-        "codex-mini-latest": "codex-mini-latest",
-        "gpt-5.1-codex-mini": "gpt-5.1-codex-mini",
     }
     return mapping.get(base, base)
 
@@ -72,10 +71,9 @@ def get_model_list(
         ("gpt-5-codex", ["high", "medium", "low"]),
         ("gpt-5.2-codex", ["xhigh", "high", "medium", "low"]),
         ("gpt-5.3-codex", ["xhigh", "high", "medium", "low"]),
+        ("gpt-5.3-codex-spark", ["xhigh", "high", "medium", "low"]),
         ("gpt-5.1-codex", ["high", "medium", "low"]),
         ("gpt-5.1-codex-max", ["xhigh", "high", "medium", "low"]),
-        ("gpt-5.1-codex-mini", []),
-        ("codex-mini", []),
     ]
     
     model_ids: List[str] = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,4 +31,6 @@ packages = ["gptmock"]
 dev = [
     "ruff>=0.15.1",
     "langchain-openai>=1.1.9",
+    "pytest>=8.0.0",
+    "pytest-asyncio>=0.25.0",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@ Usage:
 from __future__ import annotations
 
 import os
+from typing import List
 
 import pytest
 
@@ -25,12 +26,18 @@ TEST_PROMPT = "Say 'hello' and nothing else."
 TIMEOUT = 120
 
 
-def get_all_models() -> list[str]:
-    """Return all base model IDs from the registry."""
+def _get_all_models() -> List[str]:
+    """Return all base model IDs from the registry (computed once at import time)."""
     return get_model_list(expose_reasoning=False)
 
 
-ALL_MODELS = get_all_models()
+ALL_MODELS: List[str] = _get_all_models()
+
+
+@pytest.fixture(scope="session")
+def all_models() -> List[str]:
+    """Session-scoped fixture providing the model list."""
+    return ALL_MODELS
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,43 @@
+"""Shared fixtures for gptmock integration tests.
+
+These tests require a running gptmock server.
+Configure the server URL via GPTMOCK_BASE_URL env var (default: http://127.0.0.1:8000).
+
+Usage:
+    # Start server first
+    gptmock serve
+
+    # Run tests
+    pytest tests/ -v
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from gptmock.services.model_registry import get_model_list
+
+BASE_URL = os.getenv("GPTMOCK_BASE_URL", "http://127.0.0.1:8000")
+OPENAI_BASE_URL = f"{BASE_URL}/v1"
+TEST_PROMPT = "Say 'hello' and nothing else."
+TIMEOUT = 120
+
+
+def get_all_models() -> list[str]:
+    """Return all base model IDs from the registry."""
+    return get_model_list(expose_reasoning=False)
+
+
+ALL_MODELS = get_all_models()
+
+
+@pytest.fixture(scope="session")
+def base_url() -> str:
+    return BASE_URL
+
+
+@pytest.fixture(scope="session")
+def openai_base_url() -> str:
+    return OPENAI_BASE_URL

--- a/tests/test_langchain_client.py
+++ b/tests/test_langchain_client.py
@@ -1,0 +1,46 @@
+"""Integration tests: LangChain client for all supported models.
+
+Validates that every model returns a valid response via langchain-openai ChatOpenAI.
+"""
+
+from __future__ import annotations
+
+import pytest
+from langchain_openai import ChatOpenAI
+
+from tests.conftest import ALL_MODELS, OPENAI_BASE_URL, TEST_PROMPT, TIMEOUT
+
+
+def _make_llm(model: str, *, streaming: bool = False) -> ChatOpenAI:
+    return ChatOpenAI(
+        base_url=OPENAI_BASE_URL,
+        api_key="test-key",  # type: ignore[arg-type]
+        model=model,
+        streaming=streaming,
+        request_timeout=TIMEOUT,
+    )
+
+
+@pytest.mark.parametrize("model", ALL_MODELS, ids=ALL_MODELS)
+def test_langchain_invoke(model: str) -> None:
+    """ChatOpenAI.invoke (non-streaming) returns content for each model."""
+    llm = _make_llm(model, streaming=False)
+    response = llm.invoke(TEST_PROMPT)
+
+    assert response.content is not None, f"[{model}] response.content is None"
+    content = str(response.content)
+    assert len(content.strip()) > 0, f"[{model}] content is empty"
+
+
+@pytest.mark.parametrize("model", ALL_MODELS, ids=ALL_MODELS)
+def test_langchain_stream(model: str) -> None:
+    """ChatOpenAI.stream returns chunks for each model."""
+    llm = _make_llm(model, streaming=True)
+
+    chunks: list[str] = []
+    for chunk in llm.stream(TEST_PROMPT):
+        if chunk.content:
+            chunks.append(str(chunk.content))
+
+    full_text = "".join(chunks)
+    assert len(full_text.strip()) > 0, f"[{model}] streamed content is empty"

--- a/tests/test_openai_client.py
+++ b/tests/test_openai_client.py
@@ -1,0 +1,76 @@
+"""Integration tests: OpenAI SDK client for all supported models.
+
+Validates that every model returns a valid response via the openai Python client.
+"""
+
+from __future__ import annotations
+
+import openai
+import pytest
+
+from tests.conftest import ALL_MODELS, OPENAI_BASE_URL, TEST_PROMPT, TIMEOUT
+
+
+def _make_client() -> openai.OpenAI:
+    return openai.OpenAI(
+        base_url=OPENAI_BASE_URL,
+        api_key="test-key",
+        timeout=TIMEOUT,
+    )
+
+
+@pytest.mark.parametrize("model", ALL_MODELS, ids=ALL_MODELS)
+def test_openai_chat_non_stream(model: str) -> None:
+    """OpenAI client chat.completions.create (non-streaming) returns content for each model."""
+    client = _make_client()
+
+    resp = client.chat.completions.create(
+        model=model,
+        messages=[{"role": "user", "content": TEST_PROMPT}],
+        stream=False,
+    )
+
+    assert resp.choices, f"[{model}] no choices returned"
+    message = resp.choices[0].message
+    assert message.content is not None, f"[{model}] message.content is None"
+    assert len(message.content.strip()) > 0, f"[{model}] content is empty"
+
+
+@pytest.mark.parametrize("model", ALL_MODELS, ids=ALL_MODELS)
+def test_openai_chat_stream(model: str) -> None:
+    """OpenAI client chat.completions.create (streaming) returns chunks for each model."""
+    client = _make_client()
+
+    stream = client.chat.completions.create(
+        model=model,
+        messages=[{"role": "user", "content": TEST_PROMPT}],
+        stream=True,
+    )
+
+    chunks: list[str] = []
+    for chunk in stream:
+        if chunk.choices:
+            delta = chunk.choices[0].delta
+            if delta.content:
+                chunks.append(delta.content)
+
+    full_text = "".join(chunks)
+    assert len(full_text.strip()) > 0, f"[{model}] streamed content is empty"
+
+
+@pytest.mark.parametrize("model", ALL_MODELS, ids=ALL_MODELS)
+def test_openai_completions(model: str) -> None:
+    """OpenAI client completions.create (legacy text) returns text for each model."""
+    client = _make_client()
+
+    resp = client.completions.create(
+        model=model,
+        prompt=TEST_PROMPT,
+        stream=False,
+    )
+
+    assert resp.choices, f"[{model}] no choices returned"
+    text = resp.choices[0].text
+    assert isinstance(text, str) and len(text.strip()) > 0, (
+        f"[{model}] completion text is empty"
+    )

--- a/tests/test_rest_api.py
+++ b/tests/test_rest_api.py
@@ -1,0 +1,96 @@
+"""Integration tests: REST API (httpx) for all supported models.
+
+Validates that every model returns a valid chat completion response
+via direct HTTP calls to /v1/chat/completions.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from tests.conftest import ALL_MODELS, OPENAI_BASE_URL, TEST_PROMPT, TIMEOUT
+
+
+@pytest.mark.parametrize("model", ALL_MODELS, ids=ALL_MODELS)
+def test_chat_completions_non_stream(model: str) -> None:
+    """POST /v1/chat/completions (non-streaming) returns valid response for each model."""
+    payload = {
+        "model": model,
+        "messages": [{"role": "user", "content": TEST_PROMPT}],
+        "stream": False,
+    }
+
+    with httpx.Client(base_url=OPENAI_BASE_URL, timeout=TIMEOUT) as client:
+        resp = client.post("/chat/completions", json=payload)
+
+    assert resp.status_code == 200, f"[{model}] status={resp.status_code} body={resp.text}"
+
+    data = resp.json()
+    assert "choices" in data, f"[{model}] missing 'choices' in response"
+    assert len(data["choices"]) > 0, f"[{model}] empty choices"
+
+    message = data["choices"][0].get("message", {})
+    content = message.get("content")
+    assert content is not None, f"[{model}] message.content is None"
+    assert isinstance(content, str), f"[{model}] content is not str: {type(content)}"
+    assert len(content.strip()) > 0, f"[{model}] content is empty"
+
+
+@pytest.mark.parametrize("model", ALL_MODELS, ids=ALL_MODELS)
+def test_chat_completions_stream(model: str) -> None:
+    """POST /v1/chat/completions (streaming) returns valid SSE chunks for each model."""
+    payload = {
+        "model": model,
+        "messages": [{"role": "user", "content": TEST_PROMPT}],
+        "stream": True,
+    }
+
+    with httpx.Client(base_url=OPENAI_BASE_URL, timeout=TIMEOUT) as client:
+        with client.stream("POST", "/chat/completions", json=payload) as resp:
+            assert resp.status_code == 200, f"[{model}] status={resp.status_code}"
+
+            chunks: list[str] = []
+            got_done = False
+
+            for line in resp.iter_lines():
+                if not line:
+                    continue
+                if line == "data: [DONE]":
+                    got_done = True
+                    break
+                if line.startswith("data: "):
+                    import json
+
+                    chunk = json.loads(line[6:])
+                    delta = chunk.get("choices", [{}])[0].get("delta", {})
+                    text = delta.get("content")
+                    if isinstance(text, str):
+                        chunks.append(text)
+
+    assert got_done, f"[{model}] stream never received [DONE]"
+    full_text = "".join(chunks)
+    assert len(full_text.strip()) > 0, f"[{model}] streamed content is empty"
+
+
+@pytest.mark.parametrize("model", ALL_MODELS, ids=ALL_MODELS)
+def test_ollama_chat(model: str) -> None:
+    """POST /api/chat (Ollama format) returns valid response for each model."""
+    payload = {
+        "model": model,
+        "messages": [{"role": "user", "content": TEST_PROMPT}],
+        "stream": False,
+    }
+
+    with httpx.Client(base_url=OPENAI_BASE_URL.rsplit("/v1", 1)[0], timeout=TIMEOUT) as client:
+        resp = client.post("/api/chat", json=payload)
+
+    assert resp.status_code == 200, f"[{model}] status={resp.status_code} body={resp.text}"
+
+    data = resp.json()
+    assert "message" in data, f"[{model}] missing 'message' in response"
+    content = data["message"].get("content")
+    assert isinstance(content, str) and len(content.strip()) > 0, (
+        f"[{model}] ollama response content is empty or missing"
+    )
+    assert data.get("done") is True, f"[{model}] ollama response 'done' is not True"

--- a/uv.lock
+++ b/uv.lock
@@ -146,6 +146,8 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "langchain-openai" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "ruff" },
 ]
 
@@ -164,6 +166,8 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "langchain-openai", specifier = ">=1.1.9" },
+    { name = "pytest", specifier = ">=8.0.0" },
+    { name = "pytest-asyncio", specifier = ">=0.25.0" },
     { name = "ruff", specifier = ">=0.15.1" },
 ]
 
@@ -233,6 +237,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490, upload-time = "2024-09-15T18:07:39.745Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442, upload-time = "2024-09-15T18:07:37.964Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
@@ -427,6 +440,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.12.5"
 source = { registry = "https://pypi.org/simple" }
@@ -506,6 +528,43 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/96/a1/ae859ffac5a3338a66b74c5e29e244fd3a3cc483c89feaf9f56c39898d75/pydantic_settings-2.13.0.tar.gz", hash = "sha256:95d875514610e8595672800a5c40b073e99e4aae467fa7c8f9c263061ea2e1fe", size = 222450, upload-time = "2026-02-15T12:11:23.476Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b0/1a/dd1b9d7e627486cf8e7523d09b70010e05a4bc41414f4ae6ce184cf0afb6/pydantic_settings-2.13.0-py3-none-any.whl", hash = "sha256:d67b576fff39cd086b595441bf9c75d4193ca9c0ed643b90360694d0f1240246", size = 58429, upload-time = "2026-02-15T12:11:22.133Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.19.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- **New model**: Add `gpt-5.3-codex-spark` support, remove discontinued `codex-mini` / `gpt-5.1-codex-mini`
- **Web search annotations**: Surface `url_citation` annotations in all response formats (non-streaming, streaming SSE, Responses API)
- **Integration tests**: Add comprehensive test suite (72 tests) covering REST API, OpenAI SDK, and LangChain clients across all supported models
- **Docs**: Update README with current model list, deprecation table, and detailed web search annotation documentation

## Changes

### Models
- Added `gpt-5.3-codex-spark` to model registry and normalization
- Removed discontinued `codex-mini` and `gpt-5.1-codex-mini`

### Web Search URL Citations
- `chat.py`: Collect `response.content_part.done` annotations for non-streaming responses
- `sse.py`: Emit annotation chunks before stop chunk in streaming responses  
- `responses.py`: Include annotations in Responses API output with fallback extraction

### Tests
- `test_rest_api.py` — httpx-based REST API tests (non-stream, stream, Ollama)
- `test_openai_client.py` — OpenAI SDK client tests (chat, stream, completions)
- `test_langchain_client.py` — LangChain ChatOpenAI tests (invoke, stream)
- `conftest.py` — shared fixtures with dynamic model list from registry
- Added `pytest` and `pytest-asyncio` to dev dependencies

## Summary by Sourcery

Add support for the gpt-5.3-codex-spark model, surface web search URL citation annotations across chat and responses APIs (including streaming), and introduce integration tests validating all supported models via REST, OpenAI SDK, and LangChain clients.

New Features:
- Expose the gpt-5.3-codex-spark model in the registry and public model list with normalization aliases.
- Propagate web search URL citation annotations into non-streaming chat responses, SSE streaming chunks, and Responses API output.

Enhancements:
- Clarify and expand README documentation for supported models, deprecated models, and web search behavior including URL citation formats.

Tests:
- Add integration tests that exercise all supported models via direct REST endpoints, OpenAI Python SDK (chat and completions), and LangChain ChatOpenAI clients.
- Introduce shared pytest fixtures that derive the test model matrix from the model registry and configure base URLs and timeouts.
- Add pytest and pytest-asyncio to development dependencies to support the new integration test suite.