### PR TITLE
fix(serve): auto-login without browser on missing credentials

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
-      start_period: 5s
+      start_period: 120s
 
   login:
     <<: *gptmock-common

--- a/gptmock/cli.py
+++ b/gptmock/cli.py
@@ -417,7 +417,7 @@ def cmd_serve(
     auth = read_auth_file()
     if not isinstance(auth, dict) or not auth.get("tokens"):
         eprint("No credentials found. Starting login flow...")
-        login_result = cmd_login(no_browser=False, verbose=verbose)
+        login_result = cmd_login(no_browser=True, verbose=verbose)
         if login_result != 0:
             eprint("Login failed. Cannot start server without credentials.")
             return login_result


### PR DESCRIPTION
Closes #4

## Summary

- When credentials are missing at server startup, trigger login flow automatically **without** opening a browser (URL-paste flow)
- Increase Docker healthcheck `start_period` from 5s → 120s to account for the login wait time
- Update README Docker Quick Start to reflect the simplified 1-step workflow

## Changes

### `gptmock/cli.py`
- `cmd_serve`: changed `no_browser=False` → `no_browser=True` in the auto-login chain, so Docker containers (which have no browser) correctly fall back to the URL-paste login flow

### `docker-compose.yml`
- `healthcheck.start_period`: `5s` → `120s` to give enough time for the user to complete login before the container is considered unhealthy

### `README.md`
- Rewrote the Docker Quick Start section to reflect the new 1-step flow: just run `docker compose up`, paste the printed URL into a browser, and the server starts automatically after auth