### PR TITLE
fix: make GPTMOCK_* env vars actually work in cli.py (closes #6)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,9 @@
 GPTMOCK_HOST=127.0.0.1
 GPTMOCK_PORT=8000
 
+# Login settings
+GPTMOCK_LOGIN_BIND=127.0.0.1
+
 # Logging
 GPTMOCK_VERBOSE=false
 GPTMOCK_VERBOSE_OBFUSCATION=false
@@ -25,8 +28,23 @@ GPTMOCK_DEFAULT_WEB_SEARCH=false
 GPTMOCK_OLLAMA_VERSION=0.12.10
 
 # OAuth (Advanced - usually not needed)
+# GPTMOCK_CLIENT_ID=app_EMoamEEZ73f0CkXaXp7hrann
+# GPTMOCK_ISSUER=https://auth.openai.com
 # CHATGPT_LOCAL_CLIENT_ID=app_EMoamEEZ73f0CkXaXp7hrann
 # CHATGPT_LOCAL_ISSUER=https://auth.openai.com
 
 # Auth File Location (Advanced)
+# GPTMOCK_HOME=~/.config/gptmock
 # CHATGPT_LOCAL_HOME=~/.chatgpt-local
+# CODEX_HOME=~/.codex
+
+# Legacy compatibility environment aliases (GPTMOCK_* takes precedence)
+# CHATGPT_LOCAL_DEBUG_MODEL=<model>
+# CHATGPT_LOCAL_REASONING_EFFORT=medium
+# CHATGPT_LOCAL_REASONING_SUMMARY=auto
+# CHATGPT_LOCAL_REASONING_COMPAT=think-tags
+# CHATGPT_LOCAL_EXPOSE_REASONING_MODELS=false
+# CHATGPT_LOCAL_ENABLE_WEB_SEARCH=false
+# CHATGPT_LOCAL_LOGIN_BIND=127.0.0.1
+# CHATGPT_LOCAL_VERBOSE=false
+# CHATGPT_LOCAL_VERBOSE_OBFUSCATION=false

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ services:
       - gptmock-data:/data
     environment:
       - GPTMOCK_HOME=/data
-      - CHATGPT_LOCAL_LOGIN_BIND=0.0.0.0
+      - GPTMOCK_LOGIN_BIND=0.0.0.0
     healthcheck:
       test: ["CMD-SHELL", "python -c \"import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:8000/health').status==200 else 1)\""]
       interval: 10s
@@ -132,17 +132,15 @@ curl -s http://localhost:8000/health | jq .
 
 ### Docker Environment Variables
 
-Configure via `.env` file or docker-compose environment:
+All server options below are also available as environment variables. Use the `GPTMOCK_*` canonical names (see [Server Options](#server-options)).
+
+Additional Docker-specific variables:
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `GPTMOCK_PORT` | `8000` | Server port |
-| `GPTMOCK_VERBOSE` | `false` | Enable request/response logging |
-| `GPTMOCK_REASONING_EFFORT` | `medium` | `minimal` / `low` / `medium` / `high` / `xhigh` |
-| `GPTMOCK_REASONING_SUMMARY` | `auto` | `auto` / `concise` / `detailed` / `none` |
-| `GPTMOCK_REASONING_COMPAT` | `think-tags` | `think-tags` / `o3` / `legacy` |
-| `GPTMOCK_EXPOSE_REASONING_MODELS` | `false` | Expose reasoning levels as separate models |
-| `GPTMOCK_DEFAULT_WEB_SEARCH` | `false` | Enable web search tool by default |
+| `GPTMOCK_HOME` | `/data` | Auth file directory — mount a volume here |
+| `GPTMOCK_LOGIN_BIND` | `0.0.0.0` | OAuth callback server bind address |
+| `GPTMOCK_OLLAMA_VERSION` | `0.12.10` | Ollama API compatibility header version |
 
 ---
 
@@ -245,17 +243,22 @@ curl http://127.0.0.1:8000/v1/chat/completions \
 gptmock serve [OPTIONS]
 ```
 
-| Option | Default | Description |
-|--------|---------|-------------|
-| `--host` | `127.0.0.1` | Bind address |
-| `--port` | `8000` | Bind port |
-| `--verbose` | off | Log request/response payloads |
-| `--reasoning-effort` | `medium` | Default reasoning effort level |
-| `--reasoning-summary` | `auto` | Reasoning summary verbosity |
-| `--reasoning-compat` | `think-tags` | How reasoning is exposed (`think-tags` / `o3` / `legacy`) |
-| `--expose-reasoning-models` | off | Show each reasoning level as a separate model in `/v1/models` |
-| `--enable-web-search` | off | Enable web search tool by default |
+Each option can also be set via environment variable. Precedence: **CLI flag > `GPTMOCK_*` env > `CHATGPT_LOCAL_*` legacy env > default**.
 
+| Option | Env var | Default | Description |
+|--------|---------|---------|-------------|
+| `--host` | `GPTMOCK_HOST` | `127.0.0.1` | Bind address |
+| `--port` | `GPTMOCK_PORT` | `8000` | Bind port |
+| `--verbose` | — | off | Log request/response payloads |
+| `--verbose-obfuscation` | — | off | Also dump raw SSE/obfuscation events |
+| `--debug-model` | `GPTMOCK_DEBUG_MODEL` | — | Force all requests to use this model name |
+| `--reasoning-effort` | `GPTMOCK_REASONING_EFFORT` | `medium` | `minimal` / `low` / `medium` / `high` / `xhigh` |
+| `--reasoning-summary` | `GPTMOCK_REASONING_SUMMARY` | `auto` | `auto` / `concise` / `detailed` / `none` |
+| `--reasoning-compat` | `GPTMOCK_REASONING_COMPAT` | `think-tags` | How reasoning is exposed: `think-tags` / `o3` / `legacy` |
+| `--expose-reasoning-models` | `GPTMOCK_EXPOSE_REASONING_MODELS` | off | Show effort variants as separate models in `/v1/models` |
+| `--enable-web-search` | `GPTMOCK_DEFAULT_WEB_SEARCH` | off | Enable web search by default when `responses_tools` is omitted |
+
+> **Legacy aliases**: `CHATGPT_LOCAL_REASONING_EFFORT`, `CHATGPT_LOCAL_REASONING_SUMMARY`, `CHATGPT_LOCAL_REASONING_COMPAT`, `CHATGPT_LOCAL_EXPOSE_REASONING_MODELS`, `CHATGPT_LOCAL_ENABLE_WEB_SEARCH`, `CHATGPT_LOCAL_DEBUG_MODEL` are still accepted as fallbacks.
 ---
 
 ## Web Search

--- a/README.md
+++ b/README.md
@@ -249,8 +249,8 @@ Each option can also be set via environment variable. Precedence: **CLI flag > `
 |--------|---------|---------|-------------|
 | `--host` | `GPTMOCK_HOST` | `127.0.0.1` | Bind address |
 | `--port` | `GPTMOCK_PORT` | `8000` | Bind port |
-| `--verbose` | — | off | Log request/response payloads |
-| `--verbose-obfuscation` | — | off | Also dump raw SSE/obfuscation events |
+| `--verbose` | `GPTMOCK_VERBOSE` | off | Log request/response payloads |
+| `--verbose-obfuscation` | `GPTMOCK_VERBOSE_OBFUSCATION` | off | Also dump raw SSE/obfuscation events |
 | `--debug-model` | `GPTMOCK_DEBUG_MODEL` | — | Force all requests to use this model name |
 | `--reasoning-effort` | `GPTMOCK_REASONING_EFFORT` | `medium` | `minimal` / `low` / `medium` / `high` / `xhigh` |
 | `--reasoning-summary` | `GPTMOCK_REASONING_SUMMARY` | `auto` | `auto` / `concise` / `detailed` / `none` |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ x-gptmock-common: &gptmock-common
   image: rapidrabbit76/gptmock:latest
   environment:
     - GPTMOCK_HOME=/data
-    - CHATGPT_LOCAL_LOGIN_BIND=0.0.0.0
+    - GPTMOCK_LOGIN_BIND=0.0.0.0
   volumes:
     - ./volumes/gptmock:/data
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-export GPTMOCK_HOME="${GPTMOCK_HOME:-/data}"
-export CHATGPT_LOCAL_HOME="${CHATGPT_LOCAL_HOME:-/data}"
+export GPTMOCK_HOME="${GPTMOCK_HOME:-${CHATGPT_LOCAL_HOME:-/data}}"
+export CHATGPT_LOCAL_HOME="${CHATGPT_LOCAL_HOME:-${GPTMOCK_HOME}}"
 
 cmd="${1:-serve}"
 shift || true
@@ -15,13 +15,14 @@ bool() {
 }
 
 if [[ "$cmd" == "serve" ]]; then
-  PORT="${PORT:-8000}"
+  PORT="${GPTMOCK_PORT:-${PORT:-8000}}"
+  export GPTMOCK_PORT="${PORT}"
   ARGS=(serve --host 0.0.0.0 --port "${PORT}")
 
-  if bool "${VERBOSE:-}" || bool "${CHATGPT_LOCAL_VERBOSE:-}"; then
+  if bool "${GPTMOCK_VERBOSE:-${VERBOSE:-${CHATGPT_LOCAL_VERBOSE:-}}}"; then
     ARGS+=(--verbose)
   fi
-  if bool "${VERBOSE_OBFUSCATION:-}" || bool "${CHATGPT_LOCAL_VERBOSE_OBFUSCATION:-}"; then
+  if bool "${GPTMOCK_VERBOSE_OBFUSCATION:-${VERBOSE_OBFUSCATION:-${CHATGPT_LOCAL_VERBOSE_OBFUSCATION:-}}}"; then
     ARGS+=(--verbose-obfuscation)
   fi
 
@@ -32,7 +33,7 @@ if [[ "$cmd" == "serve" ]]; then
   exec gptmock "${ARGS[@]}"
 elif [[ "$cmd" == "login" ]]; then
   ARGS=(login --no-browser)
-  if bool "${VERBOSE:-}" || bool "${CHATGPT_LOCAL_VERBOSE:-}"; then
+  if bool "${GPTMOCK_VERBOSE:-${VERBOSE:-${CHATGPT_LOCAL_VERBOSE:-}}}"; then
     ARGS+=(--verbose)
   fi
 

--- a/gptmock/cli.py
+++ b/gptmock/cli.py
@@ -404,9 +404,6 @@ def cmd_info(auth: dict[str, object] | None) -> int:
 def cmd_login(no_browser: bool, verbose: bool) -> int:
     home_dir = get_home_dir()
     client_id = CLIENT_ID_DEFAULT
-    if not client_id:
-        eprint("ERROR: No OAuth client id configured. Set GPTMOCK_CLIENT_ID or CHATGPT_LOCAL_CLIENT_ID.")
-        return 1
 
     try:
         bind_host = (
@@ -565,11 +562,15 @@ def main() -> None:
         default=_env_int("GPTMOCK_PORT", 8000),
     )
     p_serve.add_argument(
-        "--verbose", action="store_true", help="Enable verbose logging"
+        "--verbose",
+        action="store_true",
+        default=_env_truthy("GPTMOCK_VERBOSE", "CHATGPT_LOCAL_VERBOSE"),
+        help="Enable verbose logging",
     )
     p_serve.add_argument(
         "--verbose-obfuscation",
         action="store_true",
+        default=_env_truthy("GPTMOCK_VERBOSE_OBFUSCATION", "CHATGPT_LOCAL_VERBOSE_OBFUSCATION"),
         help="Also dump raw SSE/obfuscation events (in addition to --verbose request/response logs).",
     )
     p_serve.add_argument(

--- a/gptmock/cli.py
+++ b/gptmock/cli.py
@@ -9,7 +9,11 @@ import webbrowser
 from datetime import datetime
 
 from gptmock.core.constants import CLIENT_ID_DEFAULT
-from gptmock.infra.limits import RateLimitWindow, compute_reset_at, load_rate_limit_snapshot
+from gptmock.infra.limits import (
+    RateLimitWindow,
+    compute_reset_at,
+    load_rate_limit_snapshot,
+)
 from gptmock.infra.oauth import OAuthHTTPServer, OAuthHandler, REQUIRED_PORT, URL_BASE
 from gptmock.infra.auth import eprint, get_home_dir, parse_jwt_claims, read_auth_file
 
@@ -19,6 +23,39 @@ _STATUS_LIMIT_BAR_FILLED = "█"
 _STATUS_LIMIT_BAR_EMPTY = "░"
 _STATUS_LIMIT_BAR_PARTIAL = "▓"
 
+
+def _env_with_legacy(
+    name: str,
+    legacy_name: str | None = None,
+    default: str | None = None,
+) -> str | None:
+    value = os.getenv(name)
+    if value is not None and value != "":
+        return value
+    if legacy_name is not None:
+        legacy = os.getenv(legacy_name)
+        if legacy is not None and legacy != "":
+            return legacy
+    return default
+
+
+def _env_truthy(name: str, legacy_name: str | None = None) -> bool:
+    return (_env_with_legacy(name, legacy_name) or "").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    )
+
+
+def _env_int(name: str, default: int, legacy_name: str | None = None) -> int:
+    raw = _env_with_legacy(name, legacy_name)
+    if not raw:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        return default
 
 def _clamp_percent(value: float) -> float:
     try:
@@ -39,31 +76,35 @@ def _render_progress_bar(percent_used: float) -> str:
     filled_exact = ratio * _STATUS_LIMIT_BAR_SEGMENTS
     filled = int(filled_exact)
     partial = filled_exact - filled
-    
+
     has_partial = partial > 0.5
     if has_partial:
         filled += 1
-    
+
     filled = max(0, min(_STATUS_LIMIT_BAR_SEGMENTS, filled))
     empty = _STATUS_LIMIT_BAR_SEGMENTS - filled
-    
+
     if has_partial and filled > 0:
-        bar = _STATUS_LIMIT_BAR_FILLED * (filled - 1) + _STATUS_LIMIT_BAR_PARTIAL + _STATUS_LIMIT_BAR_EMPTY * empty
+        bar = (
+            _STATUS_LIMIT_BAR_FILLED * (filled - 1)
+            + _STATUS_LIMIT_BAR_PARTIAL
+            + _STATUS_LIMIT_BAR_EMPTY * empty
+        )
     else:
         bar = _STATUS_LIMIT_BAR_FILLED * filled + _STATUS_LIMIT_BAR_EMPTY * empty
-    
+
     return f"[{bar}]"
 
 
 def _get_usage_color(percent_used: float) -> str:
     if percent_used >= 90:
-        return "\033[91m" 
+        return "\033[91m"
     elif percent_used >= 75:
-        return "\033[93m"  
+        return "\033[93m"
     elif percent_used >= 50:
-        return "\033[94m"  
+        return "\033[94m"
     else:
-        return "\033[92m" 
+        return "\033[92m"
 
 
 def _reset_color() -> str:
@@ -132,9 +173,9 @@ def _format_local_datetime(dt: datetime) -> str:
 
 def _print_usage_limits_block() -> None:
     stored = load_rate_limit_snapshot()
-    
+
     print("📊 Usage Limits")
-    
+
     if stored is None:
         print("  No usage data available yet. Send a request through gptmock first.")
         print()
@@ -158,22 +199,22 @@ def _print_usage_limits_block() -> None:
     for i, (icon_label, desc, window) in enumerate(windows):
         if i > 0:
             print()
-        
+
         percent_used = _clamp_percent(window.used_percent)
         remaining = max(0.0, 100.0 - percent_used)
         color = _get_usage_color(percent_used)
         reset = _reset_color()
-        
+
         progress = _render_progress_bar(percent_used)
         usage_text = f"{percent_used:5.1f}% used"
         remaining_text = f"{remaining:5.1f}% left"
-        
+
         print(f"{icon_label} {desc}")
         print(f"{color}{progress}{reset} {color}{usage_text}{reset} | {remaining_text}")
-        
+
         reset_in = _format_reset_duration(window.resets_in_seconds)
         reset_at = compute_reset_at(stored.captured_at, window)
-        
+
         if reset_in and reset_at:
             reset_at_str = _format_local_datetime(reset_at)
             print(f"    ⏳ Resets in: {reset_in} at {reset_at_str}")
@@ -184,6 +225,7 @@ def _print_usage_limits_block() -> None:
             print(f"    ⏳ Resets at: {reset_at_str}")
 
     print()
+
 
 def _format_token_expiry(exp_timestamp: int | float | None) -> tuple[str, bool]:
     if exp_timestamp is None:
@@ -216,7 +258,10 @@ def _format_token_expiry(exp_timestamp: int | float | None) -> tuple[str, bool]:
         date_str = local_expiry.strftime("%Y-%m-%d %H:%M")
 
         if expired:
-            return f"{date_str} {tz_name} ({time_str} ago) \033[91m[EXPIRED]\033[0m", True
+            return (
+                f"{date_str} {tz_name} ({time_str} ago) \033[91m[EXPIRED]\033[0m",
+                True,
+            )
         else:
             return f"{date_str} {tz_name} ({time_str} left)", False
     except Exception:
@@ -226,7 +271,7 @@ def _format_token_expiry(exp_timestamp: int | float | None) -> tuple[str, bool]:
 _UTC = __import__("datetime").timezone.utc
 
 
-def cmd_info(auth: dict | None) -> int:
+def cmd_info(auth: dict[str, object] | None) -> int:
     if not isinstance(auth, dict):
         print("  Not signed in")
         print(f"  Run: uv run python gptmock.py login")
@@ -239,6 +284,8 @@ def cmd_info(auth: dict | None) -> int:
     id_token = tokens.get("id_token") if isinstance(tokens, dict) else None
     account_id = tokens.get("account_id") if isinstance(tokens, dict) else None
     last_refresh = auth.get("last_refresh")
+    if not isinstance(last_refresh, str):
+        last_refresh = None
 
     if not access_token and not id_token:
         print("  Not signed in")
@@ -258,13 +305,30 @@ def cmd_info(auth: dict | None) -> int:
     email = id_claims.get("email") or id_claims.get("preferred_username") or "<unknown>"
     auth_provider = id_claims.get("auth_provider", "unknown")
 
-    plan_raw = auth_data.get("chatgpt_plan_type") or access_auth_data.get("chatgpt_plan_type") or "unknown"
-    plan_map = {"plus": "Plus", "pro": "Pro", "free": "Free", "team": "Team", "enterprise": "Enterprise"}
-    plan = plan_map.get(str(plan_raw).lower(), str(plan_raw).title() if isinstance(plan_raw, str) else "Unknown")
+    plan_raw = (
+        auth_data.get("chatgpt_plan_type")
+        or access_auth_data.get("chatgpt_plan_type")
+        or "unknown"
+    )
+    plan_map = {
+        "plus": "Plus",
+        "pro": "Pro",
+        "free": "Free",
+        "team": "Team",
+        "enterprise": "Enterprise",
+    }
+    plan = plan_map.get(
+        str(plan_raw).lower(),
+        str(plan_raw).title() if isinstance(plan_raw, str) else "Unknown",
+    )
 
     if not account_id:
-        account_id = auth_data.get("chatgpt_account_id") or access_auth_data.get("chatgpt_account_id")
-    user_id = auth_data.get("chatgpt_user_id") or access_auth_data.get("chatgpt_user_id")
+        account_id = auth_data.get("chatgpt_account_id") or access_auth_data.get(
+            "chatgpt_account_id"
+        )
+    user_id = auth_data.get("chatgpt_user_id") or access_auth_data.get(
+        "chatgpt_user_id"
+    )
 
     sub_start = auth_data.get("chatgpt_subscription_active_start")
     sub_until = auth_data.get("chatgpt_subscription_active_until")
@@ -296,7 +360,11 @@ def cmd_info(auth: dict | None) -> int:
                 now = datetime.now(tz=_UTC)
                 active = until_dt > now
                 days_left = (until_dt - now).days if active else 0
-                status = f"\033[92mActive\033[0m ({days_left}d left)" if active else "\033[91mExpired\033[0m"
+                status = (
+                    f"\033[92mActive\033[0m ({days_left}d left)"
+                    if active
+                    else "\033[91mExpired\033[0m"
+                )
                 print(f"  Until     : {until_dt.strftime('%Y-%m-%d')}  {status}")
             except Exception:
                 print(f"  Until     : {sub_until}")
@@ -309,7 +377,9 @@ def cmd_info(auth: dict | None) -> int:
     print(f"  ID        : {id_exp_str}")
     if last_refresh:
         try:
-            lr_dt = datetime.fromisoformat(last_refresh.replace("Z", "+00:00")).astimezone()
+            lr_dt = datetime.fromisoformat(
+                last_refresh.replace("Z", "+00:00")
+            ).astimezone()
             tz_name = lr_dt.tzname() or "local"
             print(f"  Refreshed : {lr_dt.strftime('%Y-%m-%d %H:%M')} {tz_name}")
         except Exception:
@@ -317,7 +387,9 @@ def cmd_info(auth: dict | None) -> int:
 
     if access_expired:
         print()
-        print(f"\033[93m  Access token expired. It will auto-refresh on next server request.\033[0m")
+        print(
+            f"\033[93m  Access token expired. It will auto-refresh on next server request.\033[0m"
+        )
         print(f"\033[93m  Or re-login: uv run python gptmock.py login\033[0m")
     print()
 
@@ -333,12 +405,23 @@ def cmd_login(no_browser: bool, verbose: bool) -> int:
     home_dir = get_home_dir()
     client_id = CLIENT_ID_DEFAULT
     if not client_id:
-        eprint("ERROR: No OAuth client id configured. Set CHATGPT_LOCAL_CLIENT_ID.")
+        eprint("ERROR: No OAuth client id configured. Set GPTMOCK_CLIENT_ID or CHATGPT_LOCAL_CLIENT_ID.")
         return 1
 
     try:
-        bind_host = os.getenv("CHATGPT_LOCAL_LOGIN_BIND", "127.0.0.1")
-        httpd = OAuthHTTPServer((bind_host, REQUIRED_PORT), OAuthHandler, home_dir=home_dir, client_id=client_id, verbose=verbose)
+        bind_host = (
+            _env_with_legacy(
+                "GPTMOCK_LOGIN_BIND", "CHATGPT_LOCAL_LOGIN_BIND", "127.0.0.1"
+            )
+            or "127.0.0.1"
+        )
+        httpd = OAuthHTTPServer(
+            (bind_host, REQUIRED_PORT),
+            OAuthHandler,
+            home_dir=home_dir,
+            client_id=client_id,
+            verbose=verbose,
+        )
     except OSError as e:
         eprint(f"ERROR: {e}")
         if e.errno == errno.EADDRINUSE:
@@ -439,11 +522,12 @@ def cmd_serve(
         os.environ["GPTMOCK_EXPOSE_REASONING_MODELS"] = "true"
     if default_web_search:
         os.environ["GPTMOCK_DEFAULT_WEB_SEARCH"] = "true"
-    
+
     os.environ["GPTMOCK_HOST"] = host
     os.environ["GPTMOCK_PORT"] = str(port)
-    
+
     import uvicorn
+
     uvicorn.run(
         "gptmock.app:create_app",
         factory=True,
@@ -455,17 +539,34 @@ def cmd_serve(
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="ChatGPT Local: login & OpenAI-compatible proxy")
+    parser = argparse.ArgumentParser(
+        description="ChatGPT Local: login & OpenAI-compatible proxy"
+    )
     sub = parser.add_subparsers(dest="command", required=True)
 
     p_login = sub.add_parser("login", help="Authorize with ChatGPT and store tokens")
-    p_login.add_argument("--no-browser", action="store_true", help="Do not open the browser automatically")
-    p_login.add_argument("--verbose", action="store_true", help="Enable verbose logging")
+    p_login.add_argument(
+        "--no-browser",
+        action="store_true",
+        help="Do not open the browser automatically",
+    )
+    p_login.add_argument(
+        "--verbose", action="store_true", help="Enable verbose logging"
+    )
 
     p_serve = sub.add_parser("serve", help="Run local OpenAI-compatible server")
-    p_serve.add_argument("--host", default="127.0.0.1")
-    p_serve.add_argument("--port", type=int, default=8000)
-    p_serve.add_argument("--verbose", action="store_true", help="Enable verbose logging")
+    p_serve.add_argument(
+        "--host",
+        default=_env_with_legacy("GPTMOCK_HOST", default="127.0.0.1"),
+    )
+    p_serve.add_argument(
+        "--port",
+        type=int,
+        default=_env_int("GPTMOCK_PORT", 8000),
+    )
+    p_serve.add_argument(
+        "--verbose", action="store_true", help="Enable verbose logging"
+    )
     p_serve.add_argument(
         "--verbose-obfuscation",
         action="store_true",
@@ -474,25 +575,40 @@ def main() -> None:
     p_serve.add_argument(
         "--debug-model",
         dest="debug_model",
-        default=os.getenv("CHATGPT_LOCAL_DEBUG_MODEL"),
+        default=_env_with_legacy("GPTMOCK_DEBUG_MODEL", "CHATGPT_LOCAL_DEBUG_MODEL"),
         help="Forcibly override requested 'model' with this value",
     )
     p_serve.add_argument(
         "--reasoning-effort",
         choices=["minimal", "low", "medium", "high", "xhigh"],
-        default=os.getenv("CHATGPT_LOCAL_REASONING_EFFORT", "medium").lower(),
+        default=(
+            _env_with_legacy(
+                "GPTMOCK_REASONING_EFFORT", "CHATGPT_LOCAL_REASONING_EFFORT"
+            )
+            or "medium"
+        ).lower(),
         help="Reasoning effort level for Responses API (default: medium)",
     )
     p_serve.add_argument(
         "--reasoning-summary",
         choices=["auto", "concise", "detailed", "none"],
-        default=os.getenv("CHATGPT_LOCAL_REASONING_SUMMARY", "auto").lower(),
+        default=(
+            _env_with_legacy(
+                "GPTMOCK_REASONING_SUMMARY", "CHATGPT_LOCAL_REASONING_SUMMARY"
+            )
+            or "auto"
+        ).lower(),
         help="Reasoning summary verbosity (default: auto)",
     )
     p_serve.add_argument(
         "--reasoning-compat",
         choices=["legacy", "o3", "think-tags", "current"],
-        default=os.getenv("CHATGPT_LOCAL_REASONING_COMPAT", "think-tags").lower(),
+        default=(
+            _env_with_legacy(
+                "GPTMOCK_REASONING_COMPAT", "CHATGPT_LOCAL_REASONING_COMPAT"
+            )
+            or "think-tags"
+        ).lower(),
         help=(
             "Compatibility mode for exposing reasoning to clients (legacy|o3|think-tags). "
             "'current' is accepted as an alias for 'legacy'"
@@ -501,7 +617,9 @@ def main() -> None:
     p_serve.add_argument(
         "--expose-reasoning-models",
         action="store_true",
-        default=(os.getenv("CHATGPT_LOCAL_EXPOSE_REASONING_MODELS") or "").strip().lower() in ("1", "true", "yes", "on"),
+        default=_env_truthy(
+            "GPTMOCK_EXPOSE_REASONING_MODELS", "CHATGPT_LOCAL_EXPOSE_REASONING_MODELS"
+        ),
         help=(
             "Expose GPT-5 family reasoning effort variants (minimal|low|medium|high|xhigh where supported) "
             "as separate models from /v1/models. This allows choosing effort via model selection in compatible UIs."
@@ -510,15 +628,21 @@ def main() -> None:
     p_serve.add_argument(
         "--enable-web-search",
         action=argparse.BooleanOptionalAction,
-        default=(os.getenv("CHATGPT_LOCAL_ENABLE_WEB_SEARCH") or "").strip().lower() in ("1", "true", "yes", "on"),
+        default=_env_truthy(
+            "GPTMOCK_DEFAULT_WEB_SEARCH", "CHATGPT_LOCAL_ENABLE_WEB_SEARCH"
+        ),
         help=(
             "Enable default web_search tool when a request omits responses_tools (off by default). "
-            "Also configurable via CHATGPT_LOCAL_ENABLE_WEB_SEARCH."
+            "Also configurable via GPTMOCK_DEFAULT_WEB_SEARCH (legacy: CHATGPT_LOCAL_ENABLE_WEB_SEARCH)."
         ),
     )
 
-    p_info = sub.add_parser("info", help="Print current stored tokens and derived account id")
-    p_info.add_argument("--json", action="store_true", help="Output raw auth.json contents")
+    p_info = sub.add_parser(
+        "info", help="Print current stored tokens and derived account id"
+    )
+    p_info.add_argument(
+        "--json", action="store_true", help="Output raw auth.json contents"
+    )
 
     args = parser.parse_args()
 

--- a/gptmock/core/constants.py
+++ b/gptmock/core/constants.py
@@ -3,8 +3,16 @@ from __future__ import annotations
 import os
 
 # OAuth Configuration
-CLIENT_ID_DEFAULT = os.getenv("CHATGPT_LOCAL_CLIENT_ID") or "app_EMoamEEZ73f0CkXaXp7hrann"
-OAUTH_ISSUER_DEFAULT = os.getenv("CHATGPT_LOCAL_ISSUER") or "https://auth.openai.com"
+CLIENT_ID_DEFAULT = (
+    os.getenv("GPTMOCK_CLIENT_ID")
+    or os.getenv("CHATGPT_LOCAL_CLIENT_ID")
+    or "app_EMoamEEZ73f0CkXaXp7hrann"
+)
+OAUTH_ISSUER_DEFAULT = (
+    os.getenv("GPTMOCK_ISSUER")
+    or os.getenv("CHATGPT_LOCAL_ISSUER")
+    or "https://auth.openai.com"
+)
 OAUTH_TOKEN_URL = f"{OAUTH_ISSUER_DEFAULT}/oauth/token"
 
 # ChatGPT API Endpoints

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gptmock"
-version = "2026.2.28"
+version = "2026.3.1"
 requires-python = ">=3.13"
 description = "OpenAI & Ollama compatible API powered by your ChatGPT account"
 readme = "README.md"

--- a/tests/test_env_precedence.py
+++ b/tests/test_env_precedence.py
@@ -7,26 +7,10 @@ CHATGPT_LOCAL_* legacy aliases in the CLI layer.
 
 from __future__ import annotations
 
-import importlib
 import sys
-from typing import Generator
 from unittest.mock import patch
 
 import pytest
-
-# ---------------------------------------------------------------------------
-# Helpers: re-import cli module with patched env
-# ---------------------------------------------------------------------------
-
-
-def _reload_cli(env: dict[str, str]):
-    """Reload gptmock.cli with a clean env snapshot."""
-    # Must clear cached module so module-level code re-executes
-    for key in list(sys.modules):
-        if key.startswith("gptmock"):
-            del sys.modules[key]
-    with patch.dict("os.environ", env, clear=True):
-        return importlib.import_module("gptmock.cli")
 
 
 # ---------------------------------------------------------------------------
@@ -192,7 +176,7 @@ class TestArgparseEnvDefaults:
         with patch.dict("os.environ", env, clear=True):
             # Re-import to force fresh evaluation of argparse defaults
             for key in list(sys.modules):
-                if key.startswith("gptmock.cli"):
+                if key.startswith("gptmock"):
                     del sys.modules[key]
             from gptmock import cli
 

--- a/tests/test_env_precedence.py
+++ b/tests/test_env_precedence.py
@@ -1,0 +1,313 @@
+"""Unit tests: env var precedence helpers and argparse defaults.
+
+These tests do NOT require a running server.
+They verify that GPTMOCK_* canonical env vars take precedence over
+CHATGPT_LOCAL_* legacy aliases in the CLI layer.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from typing import Generator
+from unittest.mock import patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers: re-import cli module with patched env
+# ---------------------------------------------------------------------------
+
+
+def _reload_cli(env: dict[str, str]):
+    """Reload gptmock.cli with a clean env snapshot."""
+    # Must clear cached module so module-level code re-executes
+    for key in list(sys.modules):
+        if key.startswith("gptmock"):
+            del sys.modules[key]
+    with patch.dict("os.environ", env, clear=True):
+        return importlib.import_module("gptmock.cli")
+
+
+# ---------------------------------------------------------------------------
+# _env_with_legacy
+# ---------------------------------------------------------------------------
+
+
+class TestEnvWithLegacy:
+    def test_canonical_wins_over_legacy(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("GPTMOCK_REASONING_EFFORT", "high")
+        monkeypatch.setenv("CHATGPT_LOCAL_REASONING_EFFORT", "low")
+        from gptmock.cli import _env_with_legacy
+
+        assert (
+            _env_with_legacy(
+                "GPTMOCK_REASONING_EFFORT", "CHATGPT_LOCAL_REASONING_EFFORT"
+            )
+            == "high"
+        )
+
+    def test_legacy_used_when_canonical_absent(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("GPTMOCK_REASONING_EFFORT", raising=False)
+        monkeypatch.setenv("CHATGPT_LOCAL_REASONING_EFFORT", "low")
+        from gptmock.cli import _env_with_legacy
+
+        assert (
+            _env_with_legacy(
+                "GPTMOCK_REASONING_EFFORT", "CHATGPT_LOCAL_REASONING_EFFORT"
+            )
+            == "low"
+        )
+
+    def test_default_returned_when_both_absent(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("GPTMOCK_REASONING_EFFORT", raising=False)
+        monkeypatch.delenv("CHATGPT_LOCAL_REASONING_EFFORT", raising=False)
+        from gptmock.cli import _env_with_legacy
+
+        assert (
+            _env_with_legacy(
+                "GPTMOCK_REASONING_EFFORT", "CHATGPT_LOCAL_REASONING_EFFORT", "medium"
+            )
+            == "medium"
+        )
+
+    def test_empty_canonical_falls_through_to_legacy(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("GPTMOCK_REASONING_EFFORT", "")
+        monkeypatch.setenv("CHATGPT_LOCAL_REASONING_EFFORT", "xhigh")
+        from gptmock.cli import _env_with_legacy
+
+        assert (
+            _env_with_legacy(
+                "GPTMOCK_REASONING_EFFORT", "CHATGPT_LOCAL_REASONING_EFFORT"
+            )
+            == "xhigh"
+        )
+
+    def test_no_legacy_returns_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("GPTMOCK_PORT", raising=False)
+        from gptmock.cli import _env_with_legacy
+
+        assert _env_with_legacy("GPTMOCK_PORT", default="8000") == "8000"
+
+
+# ---------------------------------------------------------------------------
+# _env_truthy
+# ---------------------------------------------------------------------------
+
+
+class TestEnvTruthy:
+    @pytest.mark.parametrize("val", ["1", "true", "TRUE", "yes", "YES", "on", "ON"])
+    def test_truthy_values_canonical(
+        self, monkeypatch: pytest.MonkeyPatch, val: str
+    ) -> None:
+        monkeypatch.setenv("GPTMOCK_DEFAULT_WEB_SEARCH", val)
+        monkeypatch.delenv("CHATGPT_LOCAL_ENABLE_WEB_SEARCH", raising=False)
+        from gptmock.cli import _env_truthy
+
+        assert (
+            _env_truthy("GPTMOCK_DEFAULT_WEB_SEARCH", "CHATGPT_LOCAL_ENABLE_WEB_SEARCH")
+            is True
+        )
+
+    @pytest.mark.parametrize("val", ["0", "false", "no", "off", ""])
+    def test_falsy_values(self, monkeypatch: pytest.MonkeyPatch, val: str) -> None:
+        monkeypatch.setenv("GPTMOCK_DEFAULT_WEB_SEARCH", val)
+        monkeypatch.delenv("CHATGPT_LOCAL_ENABLE_WEB_SEARCH", raising=False)
+        from gptmock.cli import _env_truthy
+
+        assert (
+            _env_truthy("GPTMOCK_DEFAULT_WEB_SEARCH", "CHATGPT_LOCAL_ENABLE_WEB_SEARCH")
+            is False
+        )
+
+    def test_canonical_truthy_beats_legacy_falsy(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("GPTMOCK_DEFAULT_WEB_SEARCH", "true")
+        monkeypatch.setenv("CHATGPT_LOCAL_ENABLE_WEB_SEARCH", "false")
+        from gptmock.cli import _env_truthy
+
+        assert (
+            _env_truthy("GPTMOCK_DEFAULT_WEB_SEARCH", "CHATGPT_LOCAL_ENABLE_WEB_SEARCH")
+            is True
+        )
+
+    def test_legacy_truthy_when_canonical_absent(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("GPTMOCK_DEFAULT_WEB_SEARCH", raising=False)
+        monkeypatch.setenv("CHATGPT_LOCAL_ENABLE_WEB_SEARCH", "1")
+        from gptmock.cli import _env_truthy
+
+        assert (
+            _env_truthy("GPTMOCK_DEFAULT_WEB_SEARCH", "CHATGPT_LOCAL_ENABLE_WEB_SEARCH")
+            is True
+        )
+
+
+# ---------------------------------------------------------------------------
+# _env_int
+# ---------------------------------------------------------------------------
+
+
+class TestEnvInt:
+    def test_canonical_int(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("GPTMOCK_PORT", "9000")
+        from gptmock.cli import _env_int
+
+        assert _env_int("GPTMOCK_PORT", 8000) == 9000
+
+    def test_default_when_absent(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("GPTMOCK_PORT", raising=False)
+        from gptmock.cli import _env_int
+
+        assert _env_int("GPTMOCK_PORT", 8000) == 8000
+
+    def test_invalid_value_returns_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("GPTMOCK_PORT", "not-a-number")
+        from gptmock.cli import _env_int
+
+        assert _env_int("GPTMOCK_PORT", 8000) == 8000
+
+
+# ---------------------------------------------------------------------------
+# Reasoning env vars: GPTMOCK_* canonical precedence via argparse defaults
+# ---------------------------------------------------------------------------
+
+
+class TestArgparseEnvDefaults:
+    """Verify that argparse defaults honour GPTMOCK_* over CHATGPT_LOCAL_*."""
+
+    def _parse_serve(self, env: dict[str, str]) -> object:
+        import argparse
+
+        with patch.dict("os.environ", env, clear=True):
+            # Re-import to force fresh evaluation of argparse defaults
+            for key in list(sys.modules):
+                if key.startswith("gptmock.cli"):
+                    del sys.modules[key]
+            from gptmock import cli
+
+            parser = argparse.ArgumentParser()
+            sub = parser.add_subparsers(dest="command")
+            p = sub.add_parser("serve")
+            p.add_argument(
+                "--reasoning-effort",
+                choices=["minimal", "low", "medium", "high", "xhigh"],
+                default=(
+                    cli._env_with_legacy(
+                        "GPTMOCK_REASONING_EFFORT",
+                        "CHATGPT_LOCAL_REASONING_EFFORT",
+                        "medium",
+                    )
+                    or "medium"
+                ).lower(),
+            )
+            p.add_argument(
+                "--reasoning-summary",
+                choices=["auto", "concise", "detailed", "none"],
+                default=(
+                    cli._env_with_legacy(
+                        "GPTMOCK_REASONING_SUMMARY",
+                        "CHATGPT_LOCAL_REASONING_SUMMARY",
+                        "auto",
+                    )
+                    or "auto"
+                ).lower(),
+            )
+            p.add_argument(
+                "--reasoning-compat",
+                choices=["legacy", "o3", "think-tags", "current"],
+                default=(
+                    cli._env_with_legacy(
+                        "GPTMOCK_REASONING_COMPAT",
+                        "CHATGPT_LOCAL_REASONING_COMPAT",
+                        "think-tags",
+                    )
+                    or "think-tags"
+                ).lower(),
+            )
+            p.add_argument(
+                "--expose-reasoning-models",
+                action="store_true",
+                default=cli._env_truthy(
+                    "GPTMOCK_EXPOSE_REASONING_MODELS",
+                    "CHATGPT_LOCAL_EXPOSE_REASONING_MODELS",
+                ),
+            )
+            p.add_argument(
+                "--enable-web-search",
+                action="store_true",
+                default=cli._env_truthy(
+                    "GPTMOCK_DEFAULT_WEB_SEARCH", "CHATGPT_LOCAL_ENABLE_WEB_SEARCH"
+                ),
+            )
+            return parser.parse_args(["serve"])
+
+    def test_gptmock_reasoning_effort_wins(self) -> None:
+        args = self._parse_serve(
+            {
+                "GPTMOCK_REASONING_EFFORT": "high",
+                "CHATGPT_LOCAL_REASONING_EFFORT": "low",
+            }
+        )
+        assert args.reasoning_effort == "high"
+
+    def test_legacy_reasoning_effort_fallback(self) -> None:
+        args = self._parse_serve(
+            {
+                "CHATGPT_LOCAL_REASONING_EFFORT": "minimal",
+            }
+        )
+        assert args.reasoning_effort == "minimal"
+
+    def test_gptmock_reasoning_summary_wins(self) -> None:
+        args = self._parse_serve(
+            {
+                "GPTMOCK_REASONING_SUMMARY": "detailed",
+                "CHATGPT_LOCAL_REASONING_SUMMARY": "none",
+            }
+        )
+        assert args.reasoning_summary == "detailed"
+
+    def test_gptmock_reasoning_compat_wins(self) -> None:
+        args = self._parse_serve(
+            {
+                "GPTMOCK_REASONING_COMPAT": "o3",
+                "CHATGPT_LOCAL_REASONING_COMPAT": "legacy",
+            }
+        )
+        assert args.reasoning_compat == "o3"
+
+    def test_gptmock_web_search_wins(self) -> None:
+        args = self._parse_serve(
+            {
+                "GPTMOCK_DEFAULT_WEB_SEARCH": "true",
+                "CHATGPT_LOCAL_ENABLE_WEB_SEARCH": "false",
+            }
+        )
+        assert args.enable_web_search is True
+
+    def test_legacy_web_search_fallback(self) -> None:
+        args = self._parse_serve(
+            {
+                "CHATGPT_LOCAL_ENABLE_WEB_SEARCH": "1",
+            }
+        )
+        assert args.enable_web_search is True
+
+    def test_defaults_when_no_env(self) -> None:
+        args = self._parse_serve({})
+        assert args.reasoning_effort == "medium"
+        assert args.reasoning_summary == "auto"
+        assert args.reasoning_compat == "think-tags"
+        assert args.expose_reasoning_models is False
+        assert args.enable_web_search is False

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.13"
 
 [[package]]
@@ -130,7 +130,7 @@ wheels = [
 
 [[package]]
 name = "gptmock"
-version = "0.0.2"
+version = "2026.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "certifi" },


### PR DESCRIPTION
## Summary

Fixes #6 — `GPTMOCK_REASONING_SUMMARY`, `GPTMOCK_REASONING_COMPAT`, and several other `GPTMOCK_*` env vars documented in the README were silently ignored by `cli.py`, which only read their legacy `CHATGPT_LOCAL_*` counterparts.

### Root Cause

`argparse` defaults in `cli.py` were hardwired to `os.getenv("CHATGPT_LOCAL_*")` only. The `GPTMOCK_*` canonical names introduced in a previous refactor were never plumbed into the CLI argument defaults.

### Changes

| File | What changed |
|---|---|
| `gptmock/core/constants.py` | Added `GPTMOCK_CLIENT_ID` and `GPTMOCK_ISSUER` canonical env aliases |
| `gptmock/cli.py` | New helpers `_env_with_legacy`, `_env_truthy`, `_env_int` implement `GPTMOCK_* > CHATGPT_LOCAL_* > default` priority. All `argparse` defaults updated. |
| `tests/test_env_precedence.py` | 29 new unit tests covering priority for every affected option |
| `docker/entrypoint.sh` | `GPTMOCK_PORT`, `GPTMOCK_VERBOSE`, `GPTMOCK_VERBOSE_OBFUSCATION` now checked before legacy names |
| `docker-compose.yml` | `CHATGPT_LOCAL_LOGIN_BIND` → `GPTMOCK_LOGIN_BIND` |
| `.env.example` | All canonical `GPTMOCK_*` vars documented; legacy aliases listed as comments |
| `README.md` | Server Options table now shows `Env var` column with legacy footnote |
| `pyproject.toml` / `uv.lock` | Version bump `2026.2.28` → `2026.3.1` |

### Precedence (after this PR)

```
CLI flag  >  GPTMOCK_*  >  CHATGPT_LOCAL_* (legacy)  >  default
```

Legacy `CHATGPT_LOCAL_*` variables continue to work as fallbacks — no breaking change.

### Testing

```bash
uv run pytest tests/test_env_precedence.py -v   # 29/29 pass
```