### PR TITLE
feat: add GPT-5.4 model support

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ curl http://127.0.0.1:8000/v1/chat/completions \
 | `gpt-5.2-codex` | `low` / `medium` / `high` / `xhigh` | ✅ Supported |
 | `gpt-5.3-codex` | `low` / `medium` / `high` / `xhigh` | ✅ Supported |
 | `gpt-5.3-codex-spark` | `low` / `medium` / `high` / `xhigh` | ✅ Supported |
+| `gpt-5.4` | `low` / `medium` / `high` / `xhigh` | ✅ Supported |
 
 ### Deprecated / Unsupported Models
 

--- a/gptmock/services/model_registry.py
+++ b/gptmock/services/model_registry.py
@@ -48,6 +48,9 @@ def normalize_model_name(name: str | None, debug_model: str | None = None) -> st
         "gpt-5-codex-latest": "gpt-5-codex",
         "gpt-5.1-codex": "gpt-5.1-codex",
         "gpt-5.1-codex-max": "gpt-5.1-codex-max",
+        "gpt5.4": "gpt-5.4",
+        "gpt-5.4": "gpt-5.4",
+        "gpt-5.4-latest": "gpt-5.4",
     }
     return mapping.get(base, base)
 
@@ -81,6 +84,7 @@ def get_model_list(
         ("gpt-5.3-codex-spark", ["xhigh", "high", "medium", "low"]),
         ("gpt-5.1-codex", ["high", "medium", "low"]),
         ("gpt-5.1-codex-max", ["xhigh", "high", "medium", "low"]),
+        ("gpt-5.4", ["xhigh", "high", "medium", "low"]),
     ]
 
     model_ids: List[str] = []

--- a/gptmock/services/reasoning.py
+++ b/gptmock/services/reasoning.py
@@ -11,7 +11,7 @@ def allowed_efforts_for_model(model: str | None) -> Set[str]:
     if not base:
         return DEFAULT_REASONING_EFFORTS
     normalized = base.split(":", 1)[0]
-    if normalized.startswith("gpt-5.3") or normalized.startswith("gpt-5.2"):
+    if normalized.startswith("gpt-5.4") or normalized.startswith("gpt-5.3") or normalized.startswith("gpt-5.2"):
         return {"low", "medium", "high", "xhigh"}
     if normalized.startswith("gpt-5.1-codex-max"):
         return {"low", "medium", "high", "xhigh"}

--- a/gptmock/services/reasoning.py
+++ b/gptmock/services/reasoning.py
@@ -11,7 +11,7 @@ def allowed_efforts_for_model(model: str | None) -> Set[str]:
     if not base:
         return DEFAULT_REASONING_EFFORTS
     normalized = base.split(":", 1)[0]
-    if normalized.startswith("gpt-5.4") or normalized.startswith("gpt-5.3") or normalized.startswith("gpt-5.2"):
+    if normalized.startswith(("gpt-5.4", "gpt-5.3", "gpt-5.2")):
         return {"low", "medium", "high", "xhigh"}
     if normalized.startswith("gpt-5.1-codex-max"):
         return {"low", "medium", "high", "xhigh"}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,27 +1,22 @@
 """Shared fixtures for gptmock integration tests.
 
-These tests require a running gptmock server.
-Configure the server URL via GPTMOCK_BASE_URL env var (default: http://127.0.0.1:8000).
+No running server needed — uses FastAPI TestClient in-process.
 
 Usage:
-    # Start server first
-    gptmock serve
-
-    # Run tests
-    pytest tests/ -v
+    uv run pytest tests/ -v
+    uv run pytest tests/ -v -k "gpt-5.4"
 """
 
 from __future__ import annotations
 
-import os
-from typing import List
+from typing import Generator, List
 
 import pytest
+from starlette.testclient import TestClient
 
+from gptmock.app import create_app
 from gptmock.services.model_registry import get_model_list
 
-BASE_URL = os.getenv("GPTMOCK_BASE_URL", "http://127.0.0.1:8000")
-OPENAI_BASE_URL = f"{BASE_URL}/v1"
 TEST_PROMPT = "Say 'hello' and nothing else."
 TIMEOUT = 120
 
@@ -35,16 +30,14 @@ ALL_MODELS: List[str] = _get_all_models()
 
 
 @pytest.fixture(scope="session")
+def client() -> Generator[TestClient, None, None]:
+    """In-process TestClient — no external server required."""
+    app = create_app()
+    with TestClient(app, raise_server_exceptions=False) as c:
+        yield c
+
+
+@pytest.fixture(scope="session")
 def all_models() -> List[str]:
     """Session-scoped fixture providing the model list."""
     return ALL_MODELS
-
-
-@pytest.fixture(scope="session")
-def base_url() -> str:
-    return BASE_URL
-
-
-@pytest.fixture(scope="session")
-def openai_base_url() -> str:
-    return OPENAI_BASE_URL

--- a/tests/test_langchain_client.py
+++ b/tests/test_langchain_client.py
@@ -1,30 +1,35 @@
 """Integration tests: LangChain client for all supported models.
 
 Validates that every model returns a valid response via langchain-openai ChatOpenAI.
+No running server needed — uses FastAPI TestClient in-process.
 """
 
 from __future__ import annotations
 
 import pytest
 from langchain_openai import ChatOpenAI
+from starlette.testclient import TestClient
 
-from tests.conftest import ALL_MODELS, OPENAI_BASE_URL, TEST_PROMPT, TIMEOUT
+from tests.conftest import ALL_MODELS, TEST_PROMPT, TIMEOUT
 
 
-def _make_llm(model: str, *, streaming: bool = False) -> ChatOpenAI:
+def _make_llm(
+    model: str, http_client: TestClient, *, streaming: bool = False
+) -> ChatOpenAI:
     return ChatOpenAI(
-        base_url=OPENAI_BASE_URL,
+        base_url="http://testserver/v1",
         api_key="test-key",  # type: ignore[arg-type]
         model=model,
         streaming=streaming,
-        request_timeout=TIMEOUT,
+        timeout=TIMEOUT,
+        http_client=http_client,
     )
 
 
 @pytest.mark.parametrize("model", ALL_MODELS, ids=ALL_MODELS)
-def test_langchain_invoke(model: str) -> None:
+def test_langchain_invoke(client: TestClient, model: str) -> None:
     """ChatOpenAI.invoke (non-streaming) returns content for each model."""
-    llm = _make_llm(model, streaming=False)
+    llm = _make_llm(model, client, streaming=False)
     response = llm.invoke(TEST_PROMPT)
 
     assert response.content is not None, f"[{model}] response.content is None"
@@ -33,9 +38,9 @@ def test_langchain_invoke(model: str) -> None:
 
 
 @pytest.mark.parametrize("model", ALL_MODELS, ids=ALL_MODELS)
-def test_langchain_stream(model: str) -> None:
+def test_langchain_stream(client: TestClient, model: str) -> None:
     """ChatOpenAI.stream returns chunks for each model."""
-    llm = _make_llm(model, streaming=True)
+    llm = _make_llm(model, client, streaming=True)
 
     chunks: list[str] = []
     for chunk in llm.stream(TEST_PROMPT):

--- a/tests/test_openai_client.py
+++ b/tests/test_openai_client.py
@@ -1,30 +1,33 @@
 """Integration tests: OpenAI SDK client for all supported models.
 
 Validates that every model returns a valid response via the openai Python client.
+No running server needed — uses FastAPI TestClient in-process.
 """
 
 from __future__ import annotations
 
 import openai
 import pytest
+from starlette.testclient import TestClient
 
-from tests.conftest import ALL_MODELS, OPENAI_BASE_URL, TEST_PROMPT, TIMEOUT
+from tests.conftest import ALL_MODELS, TEST_PROMPT, TIMEOUT
 
 
-def _make_client() -> openai.OpenAI:
+def _make_openai_client(http_client: TestClient) -> openai.OpenAI:
     return openai.OpenAI(
-        base_url=OPENAI_BASE_URL,
+        base_url="http://testserver/v1",
         api_key="test-key",
         timeout=TIMEOUT,
+        http_client=http_client,
     )
 
 
 @pytest.mark.parametrize("model", ALL_MODELS, ids=ALL_MODELS)
-def test_openai_chat_non_stream(model: str) -> None:
+def test_openai_chat_non_stream(client: TestClient, model: str) -> None:
     """OpenAI client chat.completions.create (non-streaming) returns content for each model."""
-    client = _make_client()
+    oc = _make_openai_client(client)
 
-    resp = client.chat.completions.create(
+    resp = oc.chat.completions.create(
         model=model,
         messages=[{"role": "user", "content": TEST_PROMPT}],
         stream=False,
@@ -37,11 +40,11 @@ def test_openai_chat_non_stream(model: str) -> None:
 
 
 @pytest.mark.parametrize("model", ALL_MODELS, ids=ALL_MODELS)
-def test_openai_chat_stream(model: str) -> None:
+def test_openai_chat_stream(client: TestClient, model: str) -> None:
     """OpenAI client chat.completions.create (streaming) returns chunks for each model."""
-    client = _make_client()
+    oc = _make_openai_client(client)
 
-    stream = client.chat.completions.create(
+    stream = oc.chat.completions.create(
         model=model,
         messages=[{"role": "user", "content": TEST_PROMPT}],
         stream=True,
@@ -59,11 +62,11 @@ def test_openai_chat_stream(model: str) -> None:
 
 
 @pytest.mark.parametrize("model", ALL_MODELS, ids=ALL_MODELS)
-def test_openai_completions(model: str) -> None:
+def test_openai_completions(client: TestClient, model: str) -> None:
     """OpenAI client completions.create (legacy text) returns text for each model."""
-    client = _make_client()
+    oc = _make_openai_client(client)
 
-    resp = client.completions.create(
+    resp = oc.completions.create(
         model=model,
         prompt=TEST_PROMPT,
         stream=False,

--- a/tests/test_rest_api.py
+++ b/tests/test_rest_api.py
@@ -1,21 +1,21 @@
-"""Integration tests: REST API (httpx) for all supported models.
+"""Integration tests: REST API for all supported models.
 
 Validates that every model returns a valid chat completion response
-via direct HTTP calls to /v1/chat/completions.
+via direct HTTP calls. No running server needed — uses FastAPI TestClient in-process.
 """
 
 from __future__ import annotations
 
 import json
 
-import httpx
 import pytest
+from starlette.testclient import TestClient
 
-from tests.conftest import ALL_MODELS, OPENAI_BASE_URL, TEST_PROMPT, TIMEOUT
+from tests.conftest import ALL_MODELS, TEST_PROMPT, TIMEOUT
 
 
 @pytest.mark.parametrize("model", ALL_MODELS, ids=ALL_MODELS)
-def test_chat_completions_non_stream(model: str) -> None:
+def test_chat_completions_non_stream(client: TestClient, model: str) -> None:
     """POST /v1/chat/completions (non-streaming) returns valid response for each model."""
     payload = {
         "model": model,
@@ -23,10 +23,11 @@ def test_chat_completions_non_stream(model: str) -> None:
         "stream": False,
     }
 
-    with httpx.Client(base_url=OPENAI_BASE_URL, timeout=TIMEOUT) as client:
-        resp = client.post("/chat/completions", json=payload)
+    resp = client.post("/v1/chat/completions", json=payload, timeout=TIMEOUT)
 
-    assert resp.status_code == 200, f"[{model}] status={resp.status_code} body={resp.text}"
+    assert resp.status_code == 200, (
+        f"[{model}] status={resp.status_code} body={resp.text}"
+    )
 
     data = resp.json()
     assert "choices" in data, f"[{model}] missing 'choices' in response"
@@ -40,7 +41,7 @@ def test_chat_completions_non_stream(model: str) -> None:
 
 
 @pytest.mark.parametrize("model", ALL_MODELS, ids=ALL_MODELS)
-def test_chat_completions_stream(model: str) -> None:
+def test_chat_completions_stream(client: TestClient, model: str) -> None:
     """POST /v1/chat/completions (streaming) returns valid SSE chunks for each model."""
     payload = {
         "model": model,
@@ -48,25 +49,26 @@ def test_chat_completions_stream(model: str) -> None:
         "stream": True,
     }
 
-    with httpx.Client(base_url=OPENAI_BASE_URL, timeout=TIMEOUT) as client:
-        with client.stream("POST", "/chat/completions", json=payload) as resp:
-            assert resp.status_code == 200, f"[{model}] status={resp.status_code}"
+    with client.stream(
+        "POST", "/v1/chat/completions", json=payload, timeout=TIMEOUT
+    ) as resp:
+        assert resp.status_code == 200, f"[{model}] status={resp.status_code}"
 
-            chunks: list[str] = []
-            got_done = False
+        chunks: list[str] = []
+        got_done = False
 
-            for line in resp.iter_lines():
-                if not line:
-                    continue
-                if line == "data: [DONE]":
-                    got_done = True
-                    break
-                if line.startswith("data: "):
-                    chunk = json.loads(line[6:])
-                    delta = chunk.get("choices", [{}])[0].get("delta", {})
-                    text = delta.get("content")
-                    if isinstance(text, str):
-                        chunks.append(text)
+        for line in resp.iter_lines():
+            if not line:
+                continue
+            if line == "data: [DONE]":
+                got_done = True
+                break
+            if line.startswith("data: "):
+                chunk = json.loads(line[6:])
+                delta = chunk.get("choices", [{}])[0].get("delta", {})
+                text = delta.get("content")
+                if isinstance(text, str):
+                    chunks.append(text)
 
     assert got_done, f"[{model}] stream never received [DONE]"
     full_text = "".join(chunks)
@@ -74,7 +76,7 @@ def test_chat_completions_stream(model: str) -> None:
 
 
 @pytest.mark.parametrize("model", ALL_MODELS, ids=ALL_MODELS)
-def test_ollama_chat(model: str) -> None:
+def test_ollama_chat(client: TestClient, model: str) -> None:
     """POST /api/chat (Ollama format) returns valid response for each model."""
     payload = {
         "model": model,
@@ -82,10 +84,11 @@ def test_ollama_chat(model: str) -> None:
         "stream": False,
     }
 
-    with httpx.Client(base_url=OPENAI_BASE_URL.rsplit("/v1", 1)[0], timeout=TIMEOUT) as client:
-        resp = client.post("/api/chat", json=payload)
+    resp = client.post("/api/chat", json=payload, timeout=TIMEOUT)
 
-    assert resp.status_code == 200, f"[{model}] status={resp.status_code} body={resp.text}"
+    assert resp.status_code == 200, (
+        f"[{model}] status={resp.status_code} body={resp.text}"
+    )
 
     data = resp.json()
     assert "message" in data, f"[{model}] missing 'message' in response"
@@ -96,7 +99,7 @@ def test_ollama_chat(model: str) -> None:
     assert data.get("done") is True, f"[{model}] ollama response 'done' is not True"
 
 
-def test_chat_completions_non_stream_web_search_annotations() -> None:
+def test_chat_completions_non_stream_web_search_annotations(client: TestClient) -> None:
     """POST /v1/chat/completions (non-streaming) surfaces url_citation annotations when web search is enabled."""
     payload = {
         "model": "gpt-5",
@@ -111,8 +114,7 @@ def test_chat_completions_non_stream_web_search_annotations() -> None:
         "responses_tool_choice": "auto",
     }
 
-    with httpx.Client(base_url=OPENAI_BASE_URL, timeout=TIMEOUT) as client:
-        resp = client.post("/chat/completions", json=payload)
+    resp = client.post("/v1/chat/completions", json=payload, timeout=TIMEOUT)
 
     assert resp.status_code == 200, f"status={resp.status_code} body={resp.text}"
 
@@ -121,7 +123,9 @@ def test_chat_completions_non_stream_web_search_annotations() -> None:
 
     message = data["choices"][0]["message"]
     assert isinstance(message, dict)
-    assert isinstance(message.get("content"), str) and message["content"].strip(), "empty content"
+    assert isinstance(message.get("content"), str) and message["content"].strip(), (
+        "empty content"
+    )
 
     # Verify annotations are present
     annotations = message.get("annotations")
@@ -133,7 +137,13 @@ def test_chat_completions_non_stream_web_search_annotations() -> None:
     assert url_citations, "expected at least one url_citation annotation"
 
     for ann in url_citations:
-        assert isinstance(ann.get("url"), str) and ann["url"], "url_citation must have non-empty url"
-        assert isinstance(ann.get("title"), str) and ann["title"], "url_citation must have non-empty title"
-        assert isinstance(ann.get("start_index"), int), "url_citation must have start_index"
+        assert isinstance(ann.get("url"), str) and ann["url"], (
+            "url_citation must have non-empty url"
+        )
+        assert isinstance(ann.get("title"), str) and ann["title"], (
+            "url_citation must have non-empty title"
+        )
+        assert isinstance(ann.get("start_index"), int), (
+            "url_citation must have start_index"
+        )
         assert isinstance(ann.get("end_index"), int), "url_citation must have end_index"


### PR DESCRIPTION
## Summary

Closes #8

- Add `gpt-5.4` to the model registry with `low`/`medium`/`high`/`xhigh` reasoning effort levels
- Configure reasoning effort in `allowed_efforts_for_model()` (prefix-based matching)
- Update README supported models table
- Refactor integration tests to use in-process `TestClient` — no running server needed

## Details

GPT-5.4 is verified against the [Codex backend](https://github.com/openai/codex) (`codex-rs/core/models.json`). Only the base `gpt-5.4` model ID is supported by the Codex backend — `gpt-5.4-thinking` and `gpt-5.4-pro` are ChatGPT UI / OpenAI API-only names and are intentionally excluded.

### Test refactor

All integration tests (`test_rest_api.py`, `test_openai_client.py`, `test_langchain_client.py`) now use `FastAPI TestClient(create_app())` with `http_client` injection instead of connecting to an external server. This matches the existing pattern in `tests/tools/test_tool_calling.py`.

```bash
# Run tests (no server needed)
uv run pytest tests/test_rest_api.py tests/test_openai_client.py tests/test_langchain_client.py -v
```

### Files changed

| File | Change |
|------|--------|
| `gptmock/services/model_registry.py` | Add gpt-5.4 aliases + model group |
| `gptmock/services/reasoning.py` | Add gpt-5.4 prefix to xhigh effort set |
| `README.md` | Add gpt-5.4 row to supported models table |
| `tests/conftest.py` | Add `TestClient` fixture, remove external server dependency |
| `tests/test_rest_api.py` | Use `client` fixture instead of `httpx.Client` |
| `tests/test_openai_client.py` | Use `TestClient` as `http_client` for `openai.OpenAI` |
| `tests/test_langchain_client.py` | Use `TestClient` as `http_client` for `ChatOpenAI` |