### PR TITLE
feat(models): add gpt-5.4-mini support

### DIFF
--- a/gptmock/services/model_registry.py
+++ b/gptmock/services/model_registry.py
@@ -50,6 +50,9 @@ def normalize_model_name(name: str | None, debug_model: str | None = None) -> st
         "gpt5.4": "gpt-5.4",
         "gpt-5.4": "gpt-5.4",
         "gpt-5.4-latest": "gpt-5.4",
+        "gpt5.4-mini": "gpt-5.4-mini",
+        "gpt-5.4-mini": "gpt-5.4-mini",
+        "gpt-5.4-mini-latest": "gpt-5.4-mini",
     }
     return mapping.get(base, base)
 
@@ -84,6 +87,7 @@ def get_model_list(
         ("gpt-5.1-codex", ["high", "medium", "low"]),
         ("gpt-5.1-codex-max", ["xhigh", "high", "medium", "low"]),
         ("gpt-5.4", ["xhigh", "high", "medium", "low"]),
+        ("gpt-5.4-mini", ["xhigh", "high", "medium", "low"]),
     ]
 
     model_ids: list[str] = []


### PR DESCRIPTION
## Summary

- Add `gpt-5.4-mini` model to the supported model list with `xhigh`/`high`/`medium`/`low` reasoning efforts
- Add normalization mappings for `gpt5.4-mini`, `gpt-5.4-mini`, and `gpt-5.4-mini-latest` aliases

## Changes

Single file change: `gptmock/services/model_registry.py`

- `normalize_model_name()` — added 3 alias mappings
- `get_model_list()` — added model group entry

No changes needed in `reasoning.py` — `gpt-5.4-mini` is already covered by the existing `startswith("gpt-5.4")` check.

## Testing

- 145 unit tests passed
- 12 `gpt-5.4-mini` specific tests auto-generated and passed (REST API, OpenAI client, Responses API, Ollama, LangChain)
- Zero lint/type errors

Closes #10