### PR TITLE
feat(models): add gpt-5.4-fast / gpt-5.4-mini-fast via service_tier=priority

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,10 @@ curl http://127.0.0.1:8000/v1/chat/completions \
 | `gpt-5.3-codex-spark` | `low` / `medium` / `high` / `xhigh` | ✅ Supported |
 | `gpt-5.4` | `low` / `medium` / `high` / `xhigh` | ✅ Supported |
 | `gpt-5.4-mini` | `low` / `medium` / `high` / `xhigh` | ✅ Supported |
+| `gpt-5.4-fast` | `low` / `medium` / `high` / `xhigh` | ✅ Supported (priority tier) |
+| `gpt-5.4-mini-fast` | `low` / `medium` / `high` / `xhigh` | ✅ Supported (priority tier) |
+
+> **Fast variants** (`*-fast`) are synthetic aliases that map to the base model plus `service_tier="priority"` in the upstream payload. No separate endpoint or auth is required — the ChatGPT backend accepts them as paid-tier priority requests.
 
 ### Deprecated / Unsupported Models
 

--- a/gptmock/services/chat.py
+++ b/gptmock/services/chat.py
@@ -30,6 +30,7 @@ from gptmock.schemas.messages import (
 from gptmock.services.model_registry import (
     get_instructions_for_model,
     normalize_model_name,
+    resolve_upstream_model,
 )
 from gptmock.services.reasoning import (
     allowed_efforts_for_model,
@@ -105,8 +106,10 @@ async def _call_upstream(
     if isinstance(reasoning_param, dict):
         include.append("reasoning.encrypted_content")
 
+    upstream_model, service_tier = resolve_upstream_model(model)
+
     payload: dict[str, Any] = {
-        "model": model,
+        "model": upstream_model,
         "instructions": instructions
         if isinstance(instructions, str) and instructions.strip()
         else instructions,
@@ -120,6 +123,8 @@ async def _call_upstream(
         "stream": True,
         "prompt_cache_key": session_id,
     }
+    if service_tier is not None:
+        payload["service_tier"] = service_tier
     if include:
         payload["include"] = include
     if reasoning_param is not None:

--- a/gptmock/services/model_registry.py
+++ b/gptmock/services/model_registry.py
@@ -31,9 +31,18 @@ MODEL_GROUPS: list[tuple[str, list[str]]] = [
     ("gpt-5.1-codex-max", ["xhigh", "high", "medium", "low"]),
     ("gpt-5.4", ["xhigh", "high", "medium", "low"]),
     ("gpt-5.4-mini", ["xhigh", "high", "medium", "low"]),
+    ("gpt-5.4-fast", ["xhigh", "high", "medium", "low"]),
+    ("gpt-5.4-mini-fast", ["xhigh", "high", "medium", "low"]),
 ]
 
 _BASE_MODEL_IDS: frozenset[str] = frozenset(base for base, _ in MODEL_GROUPS)
+
+FAST_MODEL_ALIASES: dict[str, str] = {
+    "gpt-5.4-fast": "gpt-5.4",
+    "gpt-5.4-mini-fast": "gpt-5.4-mini",
+}
+
+FAST_SERVICE_TIER: str = "priority"
 
 
 def normalize_model_name(name: str | None, debug_model: str | None = None) -> str:
@@ -81,6 +90,12 @@ def normalize_model_name(name: str | None, debug_model: str | None = None) -> st
         "gpt5.4-mini": "gpt-5.4-mini",
         "gpt-5.4-mini": "gpt-5.4-mini",
         "gpt-5.4-mini-latest": "gpt-5.4-mini",
+        "gpt5.4-fast": "gpt-5.4-fast",
+        "gpt-5.4-fast": "gpt-5.4-fast",
+        "gpt-5.4-fast-latest": "gpt-5.4-fast",
+        "gpt5.4-mini-fast": "gpt-5.4-mini-fast",
+        "gpt-5.4-mini-fast": "gpt-5.4-mini-fast",
+        "gpt-5.4-mini-fast-latest": "gpt-5.4-mini-fast",
     }
     return mapping.get(base, base)
 
@@ -98,6 +113,13 @@ def get_instructions_for_model(
         if isinstance(gpt5_codex_instructions, str) and gpt5_codex_instructions.strip():
             return gpt5_codex_instructions
     return base_instructions
+
+
+def resolve_upstream_model(model: str) -> tuple[str, str | None]:
+    """Return (upstream_model_id, service_tier); fast aliases map to base + priority."""
+    if model in FAST_MODEL_ALIASES:
+        return FAST_MODEL_ALIASES[model], FAST_SERVICE_TIER
+    return model, None
 
 
 def get_model_list(

--- a/gptmock/services/responses.py
+++ b/gptmock/services/responses.py
@@ -26,6 +26,7 @@ from gptmock.services.chat import ChatCompletionError
 from gptmock.services.model_registry import (
     get_instructions_for_model,
     normalize_model_name,
+    resolve_upstream_model,
 )
 from gptmock.services.reasoning import allowed_efforts_for_model, build_reasoning_param
 from gptmock.services.upstream import UpstreamError, send_upstream_request
@@ -462,8 +463,10 @@ async def process_responses_api(
     if isinstance(reasoning_param, dict):
         include.append("reasoning.encrypted_content")
 
+    upstream_model, service_tier = resolve_upstream_model(model)
+
     upstream_payload: dict[str, Any] = {
-        "model": model,
+        "model": upstream_model,
         "instructions": instructions,
         "input": input_items,
         "tools": tools,
@@ -474,6 +477,8 @@ async def process_responses_api(
         "stream": True,
         "prompt_cache_key": session_id,
     }
+    if service_tier is not None:
+        upstream_payload["service_tier"] = service_tier
     if isinstance(text_obj, dict):
         upstream_payload["text"] = text_obj
     if include:

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -381,6 +381,86 @@ class TestModelRegistry:
         assert normalize_model_name("gpt-5.1-codex-mini-latest") == "gpt-5.1-codex-mini"
 
 
+class TestFastModelVariants:
+    """Verify synthetic 'fast' aliases translate to base model + service_tier=priority."""
+
+    def test_fast_variants_registered_in_model_list(self) -> None:
+        models = get_model_list(expose_reasoning=False)
+        assert "gpt-5.4-fast" in models
+        assert "gpt-5.4-mini-fast" in models
+
+    def test_fast_variants_expose_reasoning_variants(self) -> None:
+        models = get_model_list(expose_reasoning=True)
+        for effort in ("low", "medium", "high", "xhigh"):
+            assert f"gpt-5.4-fast-{effort}" in models
+            assert f"gpt-5.4-mini-fast-{effort}" in models
+
+    def test_fast_variants_reasoning_metadata(self) -> None:
+        models = {m["id"]: m for m in get_openai_models(expose_reasoning=False)}
+        expected_efforts = ["low", "medium", "high", "xhigh"]
+        assert models["gpt-5.4-fast"]["reasoning"]["supported_efforts"] == expected_efforts
+        assert models["gpt-5.4-mini-fast"]["reasoning"]["supported_efforts"] == expected_efforts
+
+    def test_normalize_fast_aliases(self) -> None:
+        assert normalize_model_name("gpt-5.4-fast") == "gpt-5.4-fast"
+        assert normalize_model_name("gpt5.4-fast") == "gpt-5.4-fast"
+        assert normalize_model_name("gpt-5.4-fast-latest") == "gpt-5.4-fast"
+        assert normalize_model_name("gpt-5.4-mini-fast") == "gpt-5.4-mini-fast"
+        assert normalize_model_name("gpt5.4-mini-fast") == "gpt-5.4-mini-fast"
+        assert normalize_model_name("gpt-5.4-mini-fast-latest") == "gpt-5.4-mini-fast"
+
+    def test_normalize_fast_with_effort_suffix_strips_effort(self) -> None:
+        assert normalize_model_name("gpt-5.4-fast-medium") == "gpt-5.4-fast"
+        assert normalize_model_name("gpt-5.4-fast-xhigh") == "gpt-5.4-fast"
+        assert normalize_model_name("gpt-5.4-mini-fast-high") == "gpt-5.4-mini-fast"
+        assert normalize_model_name("gpt-5.4-mini-fast-low") == "gpt-5.4-mini-fast"
+
+    def test_resolve_upstream_model_for_fast_aliases(self) -> None:
+        from gptmock.services.model_registry import resolve_upstream_model
+
+        assert resolve_upstream_model("gpt-5.4-fast") == ("gpt-5.4", "priority")
+        assert resolve_upstream_model("gpt-5.4-mini-fast") == ("gpt-5.4-mini", "priority")
+
+    def test_resolve_upstream_model_passes_through_regular_models(self) -> None:
+        from gptmock.services.model_registry import resolve_upstream_model
+
+        assert resolve_upstream_model("gpt-5.4") == ("gpt-5.4", None)
+        assert resolve_upstream_model("gpt-5.4-mini") == ("gpt-5.4-mini", None)
+        assert resolve_upstream_model("gpt-5") == ("gpt-5", None)
+        assert resolve_upstream_model("gpt-5.1-codex-max") == ("gpt-5.1-codex-max", None)
+
+    def test_fast_variants_allowed_efforts_match_base(self) -> None:
+        from gptmock.services.reasoning import allowed_efforts_for_model
+
+        base_efforts = allowed_efforts_for_model("gpt-5.4")
+        fast_efforts = allowed_efforts_for_model("gpt-5.4-fast")
+        mini_fast_efforts = allowed_efforts_for_model("gpt-5.4-mini-fast")
+        assert fast_efforts == base_efforts
+        assert mini_fast_efforts == base_efforts
+
+    def test_fast_variants_use_base_instructions_not_codex(self) -> None:
+        from gptmock.services.model_registry import get_instructions_for_model
+
+        base = "base instructions"
+        codex = "codex instructions"
+        assert get_instructions_for_model("gpt-5.4-fast", base, codex) == base
+        assert get_instructions_for_model("gpt-5.4-mini-fast", base, codex) == base
+
+    def test_fast_variants_served_by_openai_models_endpoint(self, client: TestClient) -> None:
+        resp = client.get("/v1/models")
+        assert resp.status_code == 200
+        ids = {m["id"] for m in resp.json()["data"]}
+        assert "gpt-5.4-fast" in ids
+        assert "gpt-5.4-mini-fast" in ids
+
+    def test_fast_variants_served_by_ollama_tags_endpoint(self, client: TestClient) -> None:
+        resp = client.get("/api/tags")
+        assert resp.status_code == 200
+        names = {m["name"] for m in resp.json()["models"]}
+        assert "gpt-5.4-fast" in names
+        assert "gpt-5.4-mini-fast" in names
+
+
 # ---------------------------------------------------------------------------
 # CORS configuration
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Add `gpt-5.4-fast` and `gpt-5.4-mini-fast` as synthetic aliases that map to their base models (`gpt-5.4`, `gpt-5.4-mini`) plus `service_tier: "priority"` in the upstream payload. The ChatGPT Codex backend explicitly rejects the literal `-fast` suffix but accepts the base model + priority tier combination — matching the `RayBytes/chatmock` fast-mode pattern.

## Background

Direct attempt with `model: "gpt-5.4-fast"` fails:
```
HTTP 400 {"detail": "The 'gpt-5.4-fast' model is not supported when using Codex with a ChatGPT account."}
```

Reverse-engineering `sst/opencode` and `RayBytes/chatmock` revealed `gpt-5.4-fast` is a local UI alias, not a real model ID. The fix is to rewrite the payload at send time:

| Alias | Upstream `model` | Upstream `service_tier` |
|---|---|---|
| `gpt-5.4-fast` | `gpt-5.4` | `priority` |
| `gpt-5.4-mini-fast` | `gpt-5.4-mini` | `priority` |

## Changes

- **`model_registry.py`** — register fast variants in `MODEL_GROUPS`, add `FAST_MODEL_ALIASES` constant and `resolve_upstream_model()` helper, extend `normalize_model_name` for short/`-latest` aliases
- **`chat.py` / `responses.py`** — translate fast alias to `(base, service_tier)` before building the upstream payload
- **`tests/test_bootstrap.py::TestFastModelVariants`** — 11 new unit tests covering registration, normalization (including effort-suffix interaction), reasoning metadata, instruction routing, and `/v1/models` + `/api/tags` exposure
- **`README.md`** — document fast variants in Supported Models

## Testing

- \`uv run ruff check gptmock/ tests/\` — ✅
- \`uv run pytest tests/test_bootstrap.py --no-testmon\` — ✅ 78/78 passed
- Real upstream probe (throwaway script, not committed):
  - \`gpt-5.4-fast\` literal → 400 \"not supported when using Codex\" ❌
  - \`gpt-5.4\` + \`service_tier=priority\` → 200 OK ✅
  - \`gpt-5.4-mini\` + \`service_tier=priority\` → 200 OK ✅
  - \`service_tier=fast\` (alternative jean/JSON-RPC value) → 400 \"Unsupported service_tier: fast\" ❌ — rules out that variant

## Note on integration tests

The 85 failures in the 5 real-upstream integration test files (\`test_rest_api.py\`, \`test_openai_client.py\`, \`test_responses_api.py\`, \`test_ollama_client.py\`, \`test_langchain_client.py\`) are **pre-existing**. Verified by running the same tests on \`main\` before this change — identical failures. They appear to be upstream environment flakiness / tool rejection unrelated to this PR.

## References

- \`RayBytes/chatmock/fast_mode.py\` — \`PRIORITY_SUPPORTED_MODELS\`
- \`RayBytes/chatmock/upstream.py\` — \`responses_payload[\"service_tier\"] = \"priority\"\`