### PR TITLE
feat(models): add gpt-5.5 / gpt-5.5-fast support

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,8 +340,10 @@ Supported image content types are PNG, JPEG, GIF, and WebP. `detail: "original"`
 | `gpt-5.3-codex` | `low` / `medium` / `high` / `xhigh` | ✅ Verified upstream |
 | `gpt-5.3-codex-spark` | `low` / `medium` / `high` / `xhigh` | ✅ Verified upstream |
 | `gpt-5.4` | `low` / `medium` / `high` / `xhigh` | ✅ Verified upstream |
+| `gpt-5.5` | `low` / `medium` / `high` / `xhigh` | ⚠️ Recognized by GPTMock, upstream availability depends on account rollout |
 | `gpt-5.4-mini` | `low` / `medium` / `high` / `xhigh` | ✅ Verified upstream |
 | `gpt-5.4-fast` | `low` / `medium` / `high` / `xhigh` | ✅ Supported (priority tier alias of `gpt-5.4`) |
+| `gpt-5.5-fast` | `low` / `medium` / `high` / `xhigh` | ✅ Supported (priority tier alias of `gpt-5.5`) |
 | `gpt-5.4-mini-fast` | `low` / `medium` / `high` / `xhigh` | ✅ Supported (priority tier alias of `gpt-5.4-mini`) |
 
 > **Fast variants** (`*-fast`) are synthetic aliases that map to the base model plus `service_tier="priority"` in the upstream payload. No separate endpoint or auth is required — the ChatGPT backend accepts them as paid-tier priority requests.

--- a/gptmock/services/model_registry.py
+++ b/gptmock/services/model_registry.py
@@ -30,8 +30,10 @@ MODEL_GROUPS: list[tuple[str, list[str]]] = [
     ("gpt-5.1-codex-mini", ["high", "medium", "low"]),
     ("gpt-5.1-codex-max", ["xhigh", "high", "medium", "low"]),
     ("gpt-5.4", ["xhigh", "high", "medium", "low"]),
+    ("gpt-5.5", ["xhigh", "high", "medium", "low"]),
     ("gpt-5.4-mini", ["xhigh", "high", "medium", "low"]),
     ("gpt-5.4-fast", ["xhigh", "high", "medium", "low"]),
+    ("gpt-5.5-fast", ["xhigh", "high", "medium", "low"]),
     ("gpt-5.4-mini-fast", ["xhigh", "high", "medium", "low"]),
 ]
 
@@ -39,6 +41,7 @@ _BASE_MODEL_IDS: frozenset[str] = frozenset(base for base, _ in MODEL_GROUPS)
 
 FAST_MODEL_ALIASES: dict[str, str] = {
     "gpt-5.4-fast": "gpt-5.4",
+    "gpt-5.5-fast": "gpt-5.5",
     "gpt-5.4-mini-fast": "gpt-5.4-mini",
 }
 
@@ -87,12 +90,18 @@ def normalize_model_name(name: str | None, debug_model: str | None = None) -> st
         "gpt5.4": "gpt-5.4",
         "gpt-5.4": "gpt-5.4",
         "gpt-5.4-latest": "gpt-5.4",
+        "gpt5.5": "gpt-5.5",
+        "gpt-5.5": "gpt-5.5",
+        "gpt-5.5-latest": "gpt-5.5",
         "gpt5.4-mini": "gpt-5.4-mini",
         "gpt-5.4-mini": "gpt-5.4-mini",
         "gpt-5.4-mini-latest": "gpt-5.4-mini",
         "gpt5.4-fast": "gpt-5.4-fast",
         "gpt-5.4-fast": "gpt-5.4-fast",
         "gpt-5.4-fast-latest": "gpt-5.4-fast",
+        "gpt5.5-fast": "gpt-5.5-fast",
+        "gpt-5.5-fast": "gpt-5.5-fast",
+        "gpt-5.5-fast-latest": "gpt-5.5-fast",
         "gpt5.4-mini-fast": "gpt-5.4-mini-fast",
         "gpt-5.4-mini-fast": "gpt-5.4-mini-fast",
         "gpt-5.4-mini-fast-latest": "gpt-5.4-mini-fast",

--- a/gptmock/services/reasoning.py
+++ b/gptmock/services/reasoning.py
@@ -27,7 +27,7 @@ def allowed_efforts_for_model(model: str | None) -> set[str]:
     if not raw:
         return DEFAULT_REASONING_EFFORTS
     normalized = strip_effort_suffix(raw)
-    if normalized.startswith(("gpt-5.4", "gpt-5.3", "gpt-5.2")):
+    if normalized.startswith(("gpt-5.5", "gpt-5.4", "gpt-5.3", "gpt-5.2")):
         return {"low", "medium", "high", "xhigh"}
     if normalized.startswith("gpt-5.1-codex-max"):
         return {"low", "medium", "high", "xhigh"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gptmock"
-version = "2026.4.17"
+version = "2026.4.28"
 requires-python = ">=3.13"
 description = "OpenAI & Ollama compatible API powered by your ChatGPT account"
 readme = "README.md"

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -386,25 +386,36 @@ class TestFastModelVariants:
 
     def test_fast_variants_registered_in_model_list(self) -> None:
         models = get_model_list(expose_reasoning=False)
+        assert "gpt-5.5" in models
         assert "gpt-5.4-fast" in models
+        assert "gpt-5.5-fast" in models
         assert "gpt-5.4-mini-fast" in models
 
     def test_fast_variants_expose_reasoning_variants(self) -> None:
         models = get_model_list(expose_reasoning=True)
         for effort in ("low", "medium", "high", "xhigh"):
             assert f"gpt-5.4-fast-{effort}" in models
+            assert f"gpt-5.5-fast-{effort}" in models
             assert f"gpt-5.4-mini-fast-{effort}" in models
 
     def test_fast_variants_reasoning_metadata(self) -> None:
         models = {m["id"]: m for m in get_openai_models(expose_reasoning=False)}
         expected_efforts = ["low", "medium", "high", "xhigh"]
+        assert models["gpt-5.5"]["reasoning"]["supported_efforts"] == expected_efforts
         assert models["gpt-5.4-fast"]["reasoning"]["supported_efforts"] == expected_efforts
+        assert models["gpt-5.5-fast"]["reasoning"]["supported_efforts"] == expected_efforts
         assert models["gpt-5.4-mini-fast"]["reasoning"]["supported_efforts"] == expected_efforts
 
     def test_normalize_fast_aliases(self) -> None:
         assert normalize_model_name("gpt-5.4-fast") == "gpt-5.4-fast"
         assert normalize_model_name("gpt5.4-fast") == "gpt-5.4-fast"
         assert normalize_model_name("gpt-5.4-fast-latest") == "gpt-5.4-fast"
+        assert normalize_model_name("gpt-5.5") == "gpt-5.5"
+        assert normalize_model_name("gpt5.5") == "gpt-5.5"
+        assert normalize_model_name("gpt-5.5-latest") == "gpt-5.5"
+        assert normalize_model_name("gpt-5.5-fast") == "gpt-5.5-fast"
+        assert normalize_model_name("gpt5.5-fast") == "gpt-5.5-fast"
+        assert normalize_model_name("gpt-5.5-fast-latest") == "gpt-5.5-fast"
         assert normalize_model_name("gpt-5.4-mini-fast") == "gpt-5.4-mini-fast"
         assert normalize_model_name("gpt5.4-mini-fast") == "gpt-5.4-mini-fast"
         assert normalize_model_name("gpt-5.4-mini-fast-latest") == "gpt-5.4-mini-fast"
@@ -412,6 +423,8 @@ class TestFastModelVariants:
     def test_normalize_fast_with_effort_suffix_strips_effort(self) -> None:
         assert normalize_model_name("gpt-5.4-fast-medium") == "gpt-5.4-fast"
         assert normalize_model_name("gpt-5.4-fast-xhigh") == "gpt-5.4-fast"
+        assert normalize_model_name("gpt-5.5-fast-medium") == "gpt-5.5-fast"
+        assert normalize_model_name("gpt-5.5-fast-xhigh") == "gpt-5.5-fast"
         assert normalize_model_name("gpt-5.4-mini-fast-high") == "gpt-5.4-mini-fast"
         assert normalize_model_name("gpt-5.4-mini-fast-low") == "gpt-5.4-mini-fast"
 
@@ -419,12 +432,14 @@ class TestFastModelVariants:
         from gptmock.services.model_registry import resolve_upstream_model
 
         assert resolve_upstream_model("gpt-5.4-fast") == ("gpt-5.4", "priority")
+        assert resolve_upstream_model("gpt-5.5-fast") == ("gpt-5.5", "priority")
         assert resolve_upstream_model("gpt-5.4-mini-fast") == ("gpt-5.4-mini", "priority")
 
     def test_resolve_upstream_model_passes_through_regular_models(self) -> None:
         from gptmock.services.model_registry import resolve_upstream_model
 
         assert resolve_upstream_model("gpt-5.4") == ("gpt-5.4", None)
+        assert resolve_upstream_model("gpt-5.5") == ("gpt-5.5", None)
         assert resolve_upstream_model("gpt-5.4-mini") == ("gpt-5.4-mini", None)
         assert resolve_upstream_model("gpt-5") == ("gpt-5", None)
         assert resolve_upstream_model("gpt-5.1-codex-max") == ("gpt-5.1-codex-max", None)
@@ -433,9 +448,13 @@ class TestFastModelVariants:
         from gptmock.services.reasoning import allowed_efforts_for_model
 
         base_efforts = allowed_efforts_for_model("gpt-5.4")
+        gpt55_efforts = allowed_efforts_for_model("gpt-5.5")
         fast_efforts = allowed_efforts_for_model("gpt-5.4-fast")
+        gpt55_fast_efforts = allowed_efforts_for_model("gpt-5.5-fast")
         mini_fast_efforts = allowed_efforts_for_model("gpt-5.4-mini-fast")
+        assert gpt55_efforts == base_efforts
         assert fast_efforts == base_efforts
+        assert gpt55_fast_efforts == base_efforts
         assert mini_fast_efforts == base_efforts
 
     def test_fast_variants_use_base_instructions_not_codex(self) -> None:
@@ -444,20 +463,25 @@ class TestFastModelVariants:
         base = "base instructions"
         codex = "codex instructions"
         assert get_instructions_for_model("gpt-5.4-fast", base, codex) == base
+        assert get_instructions_for_model("gpt-5.5-fast", base, codex) == base
         assert get_instructions_for_model("gpt-5.4-mini-fast", base, codex) == base
 
     def test_fast_variants_served_by_openai_models_endpoint(self, client: TestClient) -> None:
         resp = client.get("/v1/models")
         assert resp.status_code == 200
         ids = {m["id"] for m in resp.json()["data"]}
+        assert "gpt-5.5" in ids
         assert "gpt-5.4-fast" in ids
+        assert "gpt-5.5-fast" in ids
         assert "gpt-5.4-mini-fast" in ids
 
     def test_fast_variants_served_by_ollama_tags_endpoint(self, client: TestClient) -> None:
         resp = client.get("/api/tags")
         assert resp.status_code == 200
         names = {m["name"] for m in resp.json()["models"]}
+        assert "gpt-5.5" in names
         assert "gpt-5.4-fast" in names
+        assert "gpt-5.5-fast" in names
         assert "gpt-5.4-mini-fast" in names
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -199,7 +199,7 @@ wheels = [
 
 [[package]]
 name = "gptmock"
-version = "2026.4.17"
+version = "2026.4.28"
 source = { editable = "." }
 dependencies = [
     { name = "certifi" },


### PR DESCRIPTION
## Summary

- Register `gpt-5.5` and `gpt-5.5-fast` (priority-tier alias of `gpt-5.5`) in the model registry, including normalization for `gpt5.5`, `gpt-5.5-latest`, `gpt-5.5-fast-latest`, and `gpt-5.5-fast-<effort>` suffix stripping.
- Extend `allowed_efforts_for_model` so `gpt-5.5*` exposes the `low / medium / high / xhigh` reasoning efforts, matching the existing `gpt-5.4` family.
- Reuse the existing fast-mode wiring: `gpt-5.5-fast` resolves to upstream model `gpt-5.5` with `service_tier="priority"` via `resolve_upstream_model`, so no changes to chat/responses services are required.
- Update the README Supported Models table with both entries (\`gpt-5.5\` flagged as \"upstream availability depends on account rollout\", \`gpt-5.5-fast\` documented as a priority-tier alias).

## Tests

Extended \`tests/test_bootstrap.py::TestFastModelVariants\` to cover \`gpt-5.5\` and \`gpt-5.5-fast\` for:

- model list / reasoning-variant exposure
- \`/v1/models\` and \`/api/tags\` endpoints
- \`normalize_model_name\` (aliases, latest, effort suffix stripping)
- \`resolve_upstream_model\` (fast → base + \`priority\`; pass-through for \`gpt-5.5\`)
- \`allowed_efforts_for_model\` (matches \`gpt-5.4\` family)
- \`get_instructions_for_model\` (uses base instructions, not codex)

Commands run:

- \`uv run ruff check gptmock/services/model_registry.py gptmock/services/reasoning.py tests/test_bootstrap.py\` — ✅
- \`uv run pytest tests/test_bootstrap.py -q\` — 80 passed
- Full \`uv run pytest\` was not run to completion; integration suites hit live upstream and time out, with pre-existing failures on models the README already marks as upstream-rejected (e.g. \`gpt-5\`).

## Sample

\`\`\`bash
curl http://127.0.0.1:8000/v1/models | jq '.data[] | select(.id | startswith(\"gpt-5.5\"))'
\`\`\`

\`\`\`json
{
  \"id\": \"gpt-5.5\",
  \"object\": \"model\",
  \"owned_by\": \"owner\",
  \"reasoning\": {
    \"supported_efforts\": [\"low\", \"medium\", \"high\", \"xhigh\"],
    \"default_effort\": \"medium\"
  }
}
{
  \"id\": \"gpt-5.5-fast\",
  \"object\": \"model\",
  \"owned_by\": \"owner\",
  \"reasoning\": {
    \"supported_efforts\": [\"low\", \"medium\", \"high\", \"xhigh\"],
    \"default_effort\": \"medium\"
  }
}
\`\`\`

Closes #16.