### PR TITLE
fix: preserve system prompts and retire unsupported GPT-5.4 models

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,15 +13,14 @@
   <a href="LICENSE"><img alt="License: MIT" src="https://img.shields.io/badge/license-MIT-green.svg"></a>
 </p>
 
-> **GPTMock is maintained by [rapidrabbit76](https://github.com/rapidrabbit76/GPTMock), building on [RayBytes/chatmock](https://github.com/RayBytes/chatmock).**
-> The original project attribution, license, and upstream Docker Compose file are preserved.
+> **This is a fork of [RayBytes/chatmock](https://github.com/RayBytes/chatmock).**
 > The original Flask + synchronous `requests` stack has been replaced with **FastAPI + async `httpx`**, a layered architecture (router / service / infra), `pydantic-settings` configuration, and `uv` as the build system.
 
 Integration and coverage badges are updated from local runs. Refresh both by running `scripts/test.sh` with `GIST_TOKEN` available in your environment or `.env`.
 
-GPTMock runs a local protocol adapter in front of the ChatGPT Codex backend. OpenAI SDKs, OpenAI-compatible frontends and gateways, and Ollama-compatible clients can use the same authenticated backend without GPTMock pretending that remote models are local weights. It advertises only model names verified against that backend; availability still depends on your paid ChatGPT account.
+GPTMock runs a local protocol adapter in front of the ChatGPT Codex backend. OpenAI SDKs, OpenAI-compatible frontends and gateways, and Ollama-compatible clients can use the same authenticated backend without GPTMock pretending that remote models are local weights. Its model catalog is a configured snapshot, not a live availability check. Backend access can change before that catalog is updated; see [Supported Models](#supported-models) for dated results and known stale entries.
 
-GPTMock adapts client requests to the backend's supported format while preserving model identity, instruction text, strict function schemas, tool choice, reasoning controls, and service-tier requests. For Astra, system-message text is carried in the Responses `instructions` field so existing chat clients work without changing their prompts. The actual response model, service tier, terminal status, and remaining upstream errors are returned to the client.
+GPTMock adapts client requests to the backend's supported format while preserving model identity, instruction text, strict function schemas, tool choice, reasoning controls, and service-tier requests. For GPT-5.3 Codex Spark, GPT-5.5, GPT-5.6 Luna/Terra/Sol, and GPT-6 Astra, system-message text is carried in the Responses `instructions` field so existing chat clients can keep their system prompts. The actual response model, service tier, terminal status, and remaining upstream errors are returned to the client.
 
 > **Migration note:** `--reasoning-compat` now defaults to `standard`, which emits reasoning via `delta.reasoning_content` / `message.reasoning_content` instead of injecting `<think>` tags into `content`. Set `--reasoning-compat think-tags` (or `GPTMOCK_REASONING_COMPAT=think-tags`) to keep the old behavior.
 
@@ -35,9 +34,9 @@ GPTMock adapts client requests to the backend's supported format while preservin
 
 ## Quick Start (Docker, recommended)
 
-`docker-compose.yml` is preserved exactly from [rapidrabbit76/GPTMock](https://github.com/rapidrabbit76/GPTMock). It uses `rapidrabbit76/gptmock:latest`, the original `./volumes/gptmock` bind mount, and requires a local `.env` file. Its published ports bind to all host interfaces.
+The standard `docker-compose.yml` uses `rapidrabbit76/gptmock:latest`, the `./volumes/gptmock` bind mount, and requires a local `.env` file. Its published ports bind to all host interfaces.
 
-The commands below explicitly select `docker-compose.local.yml`, a separate configuration that builds the checked-out source and applies the hardened runtime settings. It does not overwrite or merge into the original Compose file.
+The commands below explicitly select `docker-compose.local.yml`, a separate configuration that builds the checked-out source and applies the hardened runtime settings. It does not overwrite or merge into `docker-compose.yml`. When testing an unmerged pull request, check out its branch before building; the published image and PyPI package may not contain those changes yet.
 
 ### 1. Clone and build
 
@@ -166,6 +165,8 @@ gptmock info
 
 ## Usage Examples
 
+Use an explicit model that is currently available to your ChatGPT account. The basic text examples below use `gpt-5.6-luna`, which completed direct Chat and Responses requests in the 2026-09-13 check. This does not establish every SDK or tool workflow. For authenticated deployments, add `Authorization: Bearer <GPTMOCK_API_KEY>` to the curl examples and use the configured key in SDK clients.
+
 ### Existing Docker volume migration
 
 The image runs as UID/GID `10001:10001`. The original Compose bind mount can contain files written by an older root-running image; image-layer ownership does not change host bind-mount permissions. Back up the credential directory and stop GPTMock before migrating it. On a Linux host, from the verified GPTMock checkout directory:
@@ -216,9 +217,19 @@ Use OpenCode's Responses provider as the recommended configuration. OpenCode 1.x
 
 Select `gptmock/gpt-5.6-luna` and the desired variant. OpenCode automatically sends `max_output_tokens`; GPTMock's default `omit` policy keeps the request compatible while explicitly reporting that the limit was not enforced.
 
-For `gpt-6-astra`, `@ai-sdk/openai-compatible` also works through GPTMock's Chat endpoint: text system messages are moved into upstream `instructions`. OpenCode 1.17.18 completed a real file-read tool call and its follow-up through both adapters. This Astra-specific compatibility does not establish Chat-adapter support for every other model. SDK versions may encode Responses prompts as developer input or as `instructions`.
+For `gpt-5.3-codex-spark`, `gpt-5.5`, `gpt-6-astra`, and the GPT-5.6 Luna/Terra/Sol models, GPTMock's Chat endpoint moves text system messages into upstream `instructions`. OpenCode 1.17.18 completed a real Astra file-read tool call and its follow-up through both adapters. The other listed models use the same system-message adaptation; that does not establish full client/tool compatibility for every model. SDK versions may encode Responses prompts as developer input or as `instructions`.
 
 To request maximum Astra reasoning, select `gpt-6-astra` with `--variant max` (provider option `reasoningEffort: "max"`). `gpt-6-astra-max` is not a model: that removed alias returns HTTP 400 with migration guidance instead of silently selecting another effort. `max` remains supported through the reasoning parameter.
+
+### Troubleshooting: `System messages are not allowed`
+
+Older GPTMock builds adapted text system messages only for Astra, and the first extension covered GPT-5.6 Luna/Terra/Sol. Chat clients sending system prompts to GPT-5.5 or GPT-5.3 Codex Spark could still receive HTTP 400 from the backend. The adapter now covers all six concrete models, the `gpt-5.6` alias, and their existing `*-fast` requests. No Spark fast alias is added. Existing `instructions` and system text are retained in order; developer messages and tool history remain unchanged.
+
+If this error persists, verify that the running GPTMock container includes the fix, not just that the source checkout was updated. Rebuild and recreate the GPTMock service using its existing deployment configuration and credential storage. When a gateway sits between the client and GPTMock, compare a small system-plus-user request directly against GPTMock and through the gateway before changing the client's API mode or model. A successful direct request does not by itself verify the complete Hermes or other agent workflow.
+
+The regression tests in [`tests/test_astra.py`](tests/test_astra.py) cover Chat Completions, Responses, Ollama chat/generate, fast aliases, and streaming/non-streaming requests using a simulated upstream. Live client verification is separate from these tests.
+
+**GPT-5.5 and Spark verification (2026-09-13):** both models rejected literal system messages through an unpatched Chat route, but completed non-streaming developer-message Chat requests and streaming/non-streaming Responses requests using `instructions`. After rebuilding and recreating the Docker service with the extended adapter, direct Chat requests for GPT-5.5, its existing fast alias, and Spark passed all six streaming/non-streaming checks with system, developer, and user input. Each returned HTTP 200, the expected concrete model, and the expected test marker. One earlier Spark streaming sample through the local adapter did not exactly match the requested text; follow-up and deployed checks matched. These results verify the deployed GPTMock Chat path, not an end-to-end Hermes/OpenCode workflow or LiteLLM configuration changes. Do not discard system prompts or silently substitute another model to hide this error.
 
 ### Python (OpenAI SDK)
 
@@ -231,7 +242,7 @@ client = OpenAI(
 )
 
 resp = client.chat.completions.create(
-    model="gpt-5.4",
+    model="gpt-5.6-luna",
     messages=[{"role": "user", "content": "hello world"}]
 )
 print(resp.choices[0].message.content)
@@ -245,7 +256,7 @@ from langchain_openai import ChatOpenAI
 llm = ChatOpenAI(
     base_url="http://127.0.0.1:8000/v1",
     api_key="gptmock-local",  # use GPTMOCK_API_KEY when it is configured
-    model="gpt-5.4",
+    model="gpt-5.6-luna",
 )
 response = llm.invoke("hello world")
 print(response.content)
@@ -257,7 +268,7 @@ print(response.content)
 curl http://127.0.0.1:8000/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
-    "model": "gpt-5.4",
+    "model": "gpt-5.6-luna",
     "messages": [{"role": "user", "content": "hello world"}]
   }'
 ```
@@ -266,13 +277,15 @@ curl http://127.0.0.1:8000/v1/chat/completions \
 
 GPTMock can expose the ChatGPT Codex backend's built-in image generation tool through `POST /v1/responses`. This uses your existing GPTMock / Codex OAuth credentials; no separate OpenAI API key is required.
 
+The original examples used `gpt-5.4` and `gpt-5.4-mini`; both were rejected by the tested ChatGPT Codex backend on 2026-09-13. Image generation was not revalidated with a replacement model. The following illustrates the request format only: replace `<verified-image-generation-model>` with a model whose image-generation tool access you have verified for your account. A successful text response alone does not verify image generation.
+
 Pass an `image_generation` tool in the Responses API request:
 
 ```bash
 curl http://127.0.0.1:8000/v1/responses \
   -H "Content-Type: application/json" \
   -d '{
-    "model": "gpt-5.4",
+    "model": "<verified-image-generation-model>",
     "input": [
       {
         "type": "message",
@@ -314,38 +327,35 @@ For non-streaming requests, generated images are returned as `image_generation_c
 }
 ```
 
-Decode and save the first generated image with Python:
+Given the parsed response JSON, find an image result by type rather than assuming a fixed output position:
 
 ```python
 import base64
 
-image_b64 = response["output"][1]["result"]
+image_b64 = next(
+    (item["result"] for item in response.get("output", [])
+     if item.get("type") == "image_generation_call" and item.get("result")),
+    None,
+)
+if image_b64 is None:
+    raise RuntimeError("The response did not contain a generated image")
 with open("cat.png", "wb") as fp:
     fp.write(base64.b64decode(image_b64))
 ```
 
-You can also run the included live probe script from a checked-out repository:
-
-```bash
-uv run python scripts/probe_image_generation.py \
-  --model gpt-5.4 \
-  --prompt "Use the image_generation tool to create a cute cat illustration. Return only the generated image." \
-  --output .omx/logs/cat.png
-```
-
-> **Notes:** `gpt-5.4` and `gpt-5.4-mini` have been verified with this flow. The model interprets the request and invokes the built-in tool; the image bytes come back in the `image_generation_call.result` field. Model availability and image-generation entitlements are controlled by the upstream ChatGPT Codex backend and can vary by account.
+> **Notes:** Image-generation support is account- and backend-dependent. Earlier documentation reported successful GPT-5.4/mini image generation, but that is historical evidence, not current availability.
 
 ### Local Image Inspection (`view_image`)
 
 GPTMock also supports a Codex-compatible `view_image` client-side tool for `POST /v1/responses`. Unlike `image_generation`, this is not executed by the upstream backend: GPTMock reads the local file, returns it to the model as an `input_image` function-call output, and then continues the Responses turn.
 
-Enable it per request by passing the shorthand tool:
+Enable it per request by passing the shorthand tool. This is a request-format example, not a fresh live validation: replace `<verified-image-input-model>` with a currently available model verified for image input and function calling, and use an image path readable by the GPTMock server:
 
 ```bash
 curl http://127.0.0.1:8000/v1/responses \
   -H "Content-Type: application/json" \
   -d '{
-    "model": "gpt-5.4-mini",
+    "model": "<verified-image-input-model>",
     "input": [
       {
         "type": "message",
@@ -353,7 +363,7 @@ curl http://127.0.0.1:8000/v1/responses \
         "content": [
           {
             "type": "input_text",
-            "text": "Use view_image to inspect this local image path: assets/banner.png. Describe it briefly."
+            "text": "Use view_image to inspect this local image path: /images/example.png. Describe it briefly."
           }
         ]
       }
@@ -365,6 +375,8 @@ curl http://127.0.0.1:8000/v1/responses \
 ```
 
 The shorthand is normalized to a Responses function tool named `view_image`. You can also provide an explicit function tool with the same name.
+
+**Docker:** paths are resolved inside the container, not on the client or host. The image does not include the repository's `assets/banner.png`. Mount your image directory read-only at `/images` alongside the existing credential volume, set `GPTMOCK_VIEW_IMAGE_ROOTS=/images`, and ensure the container's non-root user can read the selected file. Merely setting the allowed roots does not mount or copy any files.
 
 By default, `view_image` can read files under the server's current working directory only. Configure the readable roots when needed:
 
@@ -386,39 +398,45 @@ Supported image content types are PNG, JPEG, GIF, and WebP. `detail: "original"`
 
 ## Supported Models
 
-| Model | Reasoning Efforts | Status |
+The following snapshot combines the current registry with direct backend checks on **2026-09-13 (KST)**. The availability check used `low` effort, non-streaming, user-only Chat Completions and Responses requests. Successful responses contained the requested test text and the expected concrete model name. It did not rerun every reasoning level, tools, images, or client integration. The effort column describes GPTMock's configured validation range, not fresh verification of every level.
+
+| Model | Configured Reasoning Efforts | Observed Backend Status (2026-09-13) |
 |-------|-------------------|--------|
-| `gpt-5.3-codex-spark` | `low` / `medium` / `high` / `xhigh` | ✅ Verified upstream |
-| `gpt-5.4` | `low` / `medium` / `high` / `xhigh` | ✅ Verified upstream |
-| `gpt-5.5` | `low` / `medium` / `high` / `xhigh` | ✅ Verified upstream |
-| `gpt-5.6` | `none` / `low` / `medium` / `high` / `xhigh` / `max` | ✅ Verified alias; upstream resolves it to `gpt-5.6-sol` |
-| `gpt-5.6-sol` | `none` / `low` / `medium` / `high` / `xhigh` / `max` | ✅ Verified upstream |
-| `gpt-5.6-terra` | `none` / `low` / `medium` / `high` / `xhigh` / `max` | ✅ Verified upstream |
-| `gpt-5.6-luna` | `none` / `low` / `medium` / `high` / `xhigh` / `max` | ✅ Verified upstream |
-| `gpt-5.4-mini` | `low` / `medium` / `high` / `xhigh` | ✅ Verified upstream |
-| `gpt-6-astra` | `low` / `medium` / `high` / `xhigh` / `max` | ✅ Verified upstream on 2026-09-05 |
+| `gpt-5.3-codex-spark` | `low` / `medium` / `high` / `xhigh` | ✅ Text and `instructions` requests completed; system text is adapted by GPTMock |
+| `gpt-5.5` | `low` / `medium` / `high` / `xhigh` | ✅ Text and `instructions` requests completed; system text is adapted by GPTMock |
+| `gpt-5.6` | `none` / `low` / `medium` / `high` / `xhigh` / `max` | ✅ Completed as `gpt-5.6-sol` |
+| `gpt-5.6-sol` | `none` / `low` / `medium` / `high` / `xhigh` / `max` | ✅ Basic text requests completed |
+| `gpt-5.6-terra` | `none` / `low` / `medium` / `high` / `xhigh` / `max` | ✅ Basic text requests completed |
+| `gpt-5.6-luna` | `none` / `low` / `medium` / `high` / `xhigh` / `max` | ✅ Basic text requests completed |
+| `gpt-6-astra` | `low` / `medium` / `high` / `xhigh` / `max` | ✅ Basic text requests completed |
+
+**Removed GPT-5.4 models:** `gpt-5.4` and `gpt-5.4-mini` returned `The '…' model is not supported when using Codex with a ChatGPT account.` in the 2026-09-13 check. They and their effort variants are no longer advertised by `/v1/models` or `/api/tags`; their fast aliases are no longer registered. `/api/show` returns HTTP 404 for these removed entries. This is a dated backend/account observation, not a claim about public OpenAI API availability.
 
 Direct Docker probes on 2026-09-03 confirmed every listed GPT-5.6 reasoning effort (`none` through `max`) for Sol, Terra, and Luna through `/v1/responses`. All 18 requests completed successfully and returned the requested concrete model name.
 
 > **Fast compatibility aliases:** `*-fast` names are accepted when requested directly and add `service_tier="priority"` to the same verified base-model request. They are not separate models, are not advertised by `/v1/models` or `/api/tags`, and do not guarantee priority service. New integrations should prefer the verified base model plus an explicit `service_tier="priority"` request. GPTMock returns the actual upstream `service_tier` unchanged. The seven pre-Astra aliases were accepted on 2026-08-26 with `service_tier="default"`. Astra's priority request was separately accepted on 2026-09-05 and also returned `default`; `gpt-6-astra-fast` uses that same request-only convention.
 
+Fast aliases inherit their base model's availability. On 2026-09-13, `gpt-5.4-fast` and `gpt-5.4-mini-fast` were rejected and have since been removed from alias registration; `gpt-5.5-fast` completed as `gpt-5.5` with actual tier `default`. Recognizing an alias does not make an unavailable base model usable.
+
 > **GPT-5.6 compatibility note:** GPTMock exposes only verified GPT-5.6 model names. `gpt-5.6` follows OpenAI's documented alias to `gpt-5.6-sol`. OpenAI documents Pro as `reasoning.mode="pro"` on the same model rather than as a `*-pro` model ID, but the ChatGPT Codex backend rejected that mode in direct probes. GPTMock therefore advertises no Pro model slug and rejects `reasoning.mode` locally instead of sending a request known to be unsupported by this upstream.
 
 > **GPT-6 Astra:** `gpt-6-astra` connects directly to that exact upstream model. The [official model documentation](https://developers.openai.com/api/docs/models/gpt-6-astra) lists `low`, `medium`, `high`, `xhigh`, and `max`; direct ChatGPT Codex probes on 2026-09-05 completed at all five efforts and echoed the requested model and effort. That backend rejected `none`, `minimal`, `ultra`, `gpt-6-astra-pro`, and `reasoning.mode="pro"`. Those options are not advertised as supported. OpenAI Chat Completions and Ollama clients use GPTMock's existing Responses-backed adapter, including tool calls. See [Astra validation](docs/astra-validation.md) for the tested interfaces and limitations.
 
-> **Astra client compatibility:** the connected backend rejects a literal `system` input role. GPTMock automatically carries text from those messages into the supported `instructions` field, after any existing instructions and in message order. Developer/user messages and tool results remain in `input`. This applies to OpenAI Chat, Responses, Ollama chat, and Ollama generate's `system` field, including fast requests and streaming. Existing clients can keep their system prompts.
+> **System-message compatibility:** for GPT-5.3 Codex Spark, GPT-5.5, GPT-5.6 Luna/Terra/Sol, and GPT-6 Astra, GPTMock carries text system messages into the supported `instructions` field, after any existing instructions and in message order. Developer/user messages and tool results remain in `input`. This applies to OpenAI Chat, Responses, Ollama chat, and Ollama generate's `system` field, including existing fast aliases and streaming. Existing clients can keep their system prompts. Other models and unsupported non-text system content are passed through unchanged.
 
 > **Upstream availability note:** model availability can change independently of GPTMock releases. The older model list reflects direct probes made on 2026-08-26, GPT-5.6 was rechecked on 2026-09-03, and Astra was verified on 2026-09-05. `gpt-5`, `gpt-5.1`, `gpt-5.2`, `gpt-5-codex`, `gpt-5.1-codex`, `gpt-5.1-codex-mini`, `gpt-5.1-codex-max`, `gpt-5.2-codex`, and `gpt-5.3-codex` were rejected and are therefore not advertised.
 
 ### Deprecated / Unsupported Models
 
-Rejected names are omitted from `/v1/models` and `/api/tags`. A client can still send an arbitrary model identifier; GPTMock forwards it unchanged and preserves the upstream rejection instead of silently routing it to a different model.
+The rejected names listed above, including GPT-5.4/mini, are omitted from `/v1/models` and `/api/tags`. Explicit retired or unknown non-alias identifiers are still forwarded to upstream and its rejection is preserved, rather than being silently replaced with a different model. GPT-5.4 fast identifiers no longer receive synthetic priority translation. Certain removed aliases, such as `gpt-6-astra-max`, and unsupported reasoning options are rejected locally.
+
+Always supply a non-empty model name. Generation requests without `model` return HTTP 422. Empty or whitespace-only model names return HTTP 400 before upstream authentication, rather than implicitly selecting GPT-5.4 or another model. An explicitly configured debug-model override remains available for diagnostics.
 
 ### Request and Response Semantics
 
 | Input or event | GPTMock behavior |
 |----------------|------------------|
-| `system` and `developer` messages | For Astra, system text is moved into `instructions` and developer messages remain in `input`; other models retain the supplied roles |
+| `system` and `developer` messages | For Spark, GPT-5.5, GPT-5.6 Luna/Terra/Sol, and Astra, system text is moved into `instructions` and developer messages remain in `input`; other models retain the supplied roles |
 | Function tools with `strict: true` | Strict schema flag and parameters are preserved |
 | `tool_choice: "required"` | Forwarded as required; never weakened to `auto` |
 | Rejected tools or model options | Upstream error is returned; GPTMock does not remove tools and retry |
@@ -432,7 +450,7 @@ Rejected names are omitted from `/v1/models` and `/api/tags`. A client can still
 | Ollama model metadata | Marked as remote with zero/empty unknown size and digest values; no GGUF, Llama family, parameter size, quantization, or local evaluation timings are fabricated |
 | Ollama function calls | Arguments are native JSON objects. Streaming fragments are buffered until a valid tool-call finish; tool results are matched by name when supplied |
 
-The GPT-5.6 alias and reasoning-effort range follow [OpenAI's GPT-5.6 model guidance](https://developers.openai.com/api/docs/guides/latest-model). GPTMock's accepted options are narrower because they reflect what the ChatGPT Codex backend accepted during the dated probes above, not what may be available through a separate OpenAI API account.
+The GPT-5.6 alias and reasoning-effort range follow [OpenAI's GPT-5.6 model guidance](https://developers.openai.com/api/docs/guides/latest-model?model=gpt-5.6). GPTMock's accepted options are narrower because they reflect what the ChatGPT Codex backend accepted during the dated probes above, not what may be available through a separate OpenAI API account.
 
 The default output-token policy is intentionally compatibility-oriented. OpenAI SDKs and agent frontends commonly add an output-token field even when the user did not set one. GPTMock accepts such requests but does not claim that the limit was honored: the field is omitted only from the upstream request, a warning names the omitted field, and the HTTP response exposes the same fact. Use `--output-token-policy reject` when failing closed is preferable to frontend compatibility.
 
@@ -457,7 +475,7 @@ Docker probes on 2026-09-03 verified authenticated raw HTTP requests for tags, s
 | POST | `/v1/chat/completions` | OpenAI Chat Completions (stream / non-stream) |
 | POST | `/v1/completions` | OpenAI Text Completions |
 | POST | `/v1/responses` | OpenAI Responses API semantics |
-| GET | `/v1/models` | List available models |
+| GET | `/v1/models` | List configured model metadata; not a live availability check |
 | GET | `/api/version` | Ollama-compatible version info |
 | POST | `/api/chat` | Ollama-compatible chat |
 | POST | `/api/generate` | Ollama-compatible text generation |
@@ -474,7 +492,7 @@ Docker probes on 2026-09-03 verified authenticated raw HTTP requests for tags, s
 - **Tool / Function Calling** — including web search with URL citation annotations via `responses_tools`
 - **Image Generation** — Responses API `image_generation` tool support with base64 PNG output
 - **Local Image Inspection** — Codex-compatible `view_image` function tool for allowed local image paths
-- **Thinking Summaries** — `<think>` tags, `o3` reasoning format, or legacy mode
+- **Thinking Summaries** — `standard` mode returns `reasoning_content` by default; optional `think-tags`, `o3`, and `legacy` modes support other clients
 - **Responses API** — `POST /v1/responses` for LangChain and other clients that auto-route codex models
 - **Ollama Compatibility** — chat and generate APIs with remote-model metadata, without fabricated GGUF sizes, digests, or local evaluation timings
 - **Auto Token Refresh** — JWT tokens are refreshed automatically before expiry
@@ -585,11 +603,13 @@ data: {"choices": [{"delta": {}, "finish_reason": "stop"}]}
 
 ### Example Request
 
+This shows the web-search request format. The basic text availability check above did not revalidate web-search entitlement or tool execution for the example model.
+
 ```bash
 curl http://127.0.0.1:8000/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
-    "model": "gpt-5.4",
+    "model": "gpt-5.6-luna",
     "messages": [{"role":"user","content":"Find current METAR rules"}],
     "stream": true,
     "responses_tools": [{"type": "web_search"}],
@@ -611,5 +631,4 @@ curl http://127.0.0.1:8000/v1/chat/completions \
 ## Credits
 
 - Original project: [RayBytes/chatmock](https://github.com/RayBytes/chatmock)
-- GPTMock author and upstream maintainer: [rapidrabbit76/GPTMock](https://github.com/rapidrabbit76/GPTMock)
-- Contribution fork: [binary1215/GPTMock](https://github.com/binary1215/GPTMock)
+- This fork: [rapidrabbit76/GPTMock](https://github.com/rapidrabbit76/GPTMock)

--- a/gptmock/services/model_registry.py
+++ b/gptmock/services/model_registry.py
@@ -11,25 +11,21 @@ from gptmock.services.reasoning import (
 
 MODEL_GROUPS: list[tuple[str, list[str]]] = [
     ("gpt-5.3-codex-spark", ["xhigh", "high", "medium", "low"]),
-    ("gpt-5.4", ["xhigh", "high", "medium", "low"]),
     ("gpt-5.5", ["xhigh", "high", "medium", "low"]),
     ("gpt-5.6", ["max", "xhigh", "high", "medium", "low", "none"]),
     ("gpt-5.6-sol", ["max", "xhigh", "high", "medium", "low", "none"]),
     ("gpt-5.6-terra", ["max", "xhigh", "high", "medium", "low", "none"]),
     ("gpt-5.6-luna", ["max", "xhigh", "high", "medium", "low", "none"]),
     ("gpt-6-astra", ["max", "xhigh", "high", "medium", "low"]),
-    ("gpt-5.4-mini", ["xhigh", "high", "medium", "low"]),
 ]
 
 SYNTHETIC_MODEL_GROUPS: list[tuple[str, list[str]]] = [
-    ("gpt-5.4-fast", ["xhigh", "high", "medium", "low"]),
     ("gpt-5.5-fast", ["xhigh", "high", "medium", "low"]),
     ("gpt-5.6-fast", ["max", "xhigh", "high", "medium", "low", "none"]),
     ("gpt-5.6-sol-fast", ["max", "xhigh", "high", "medium", "low", "none"]),
     ("gpt-5.6-terra-fast", ["max", "xhigh", "high", "medium", "low", "none"]),
     ("gpt-5.6-luna-fast", ["max", "xhigh", "high", "medium", "low", "none"]),
     ("gpt-6-astra-fast", ["max", "xhigh", "high", "medium", "low"]),
-    ("gpt-5.4-mini-fast", ["xhigh", "high", "medium", "low"]),
 ]
 
 _BASE_MODEL_IDS: frozenset[str] = frozenset(
@@ -43,14 +39,12 @@ UPSTREAM_MODEL_ALIASES: dict[str, str] = {
 }
 
 FAST_MODEL_ALIASES: dict[str, str] = {
-    "gpt-5.4-fast": "gpt-5.4",
     "gpt-5.5-fast": "gpt-5.5",
     "gpt-5.6-fast": "gpt-5.6-sol",
     "gpt-5.6-sol-fast": "gpt-5.6-sol",
     "gpt-5.6-terra-fast": "gpt-5.6-terra",
     "gpt-5.6-luna-fast": "gpt-5.6-luna",
     "gpt-6-astra-fast": "gpt-6-astra",
-    "gpt-5.4-mini-fast": "gpt-5.4-mini",
 }
 
 FAST_SERVICE_TIER: str = "priority"
@@ -64,7 +58,7 @@ def normalize_model_name(name: str | None, debug_model: str | None = None) -> st
     if isinstance(debug_model, str) and debug_model.strip():
         return debug_model.strip()
     if not isinstance(name, str) or not name.strip():
-        return "gpt-5.4"
+        raise ValueError("A non-empty model name is required")
     base = name.split(":", 1)[0].strip()
     for sep in ("-", "_"):
         lowered = base.lower()
@@ -101,9 +95,6 @@ def normalize_model_name(name: str | None, debug_model: str | None = None) -> st
         "gpt5.1-codex-mini": "gpt-5.1-codex-mini",
         "gpt-5.1-codex-mini": "gpt-5.1-codex-mini",
         "gpt-5.1-codex-mini-latest": "gpt-5.1-codex-mini",
-        "gpt5.4": "gpt-5.4",
-        "gpt-5.4": "gpt-5.4",
-        "gpt-5.4-latest": "gpt-5.4",
         "gpt5.5": "gpt-5.5",
         "gpt-5.5": "gpt-5.5",
         "gpt-5.5-latest": "gpt-5.5",
@@ -122,12 +113,6 @@ def normalize_model_name(name: str | None, debug_model: str | None = None) -> st
         "gpt6-astra": "gpt-6-astra",
         "gpt-6-astra": "gpt-6-astra",
         "gpt-6-astra-latest": "gpt-6-astra",
-        "gpt5.4-mini": "gpt-5.4-mini",
-        "gpt-5.4-mini": "gpt-5.4-mini",
-        "gpt-5.4-mini-latest": "gpt-5.4-mini",
-        "gpt5.4-fast": "gpt-5.4-fast",
-        "gpt-5.4-fast": "gpt-5.4-fast",
-        "gpt-5.4-fast-latest": "gpt-5.4-fast",
         "gpt5.5-fast": "gpt-5.5-fast",
         "gpt-5.5-fast": "gpt-5.5-fast",
         "gpt-5.5-fast-latest": "gpt-5.5-fast",
@@ -146,9 +131,6 @@ def normalize_model_name(name: str | None, debug_model: str | None = None) -> st
         "gpt6-astra-fast": "gpt-6-astra-fast",
         "gpt-6-astra-fast": "gpt-6-astra-fast",
         "gpt-6-astra-fast-latest": "gpt-6-astra-fast",
-        "gpt5.4-mini-fast": "gpt-5.4-mini-fast",
-        "gpt-5.4-mini-fast": "gpt-5.4-mini-fast",
-        "gpt-5.4-mini-fast-latest": "gpt-5.4-mini-fast",
     }
     return mapping.get(base, base)
 

--- a/gptmock/services/upstream.py
+++ b/gptmock/services/upstream.py
@@ -14,9 +14,12 @@ from gptmock.infra.limits import record_rate_limits_from_response
 logger = logging.getLogger(__name__)
 
 
-def _adapt_astra_system_messages(payload: dict[str, Any]) -> dict[str, Any]:
-    """Carry text system instructions into Astra's supported instructions field."""
-    if payload.get("model") != "gpt-6-astra":
+def _adapt_system_messages(payload: dict[str, Any]) -> dict[str, Any]:
+    """Carry system text into instructions for models verified to reject the role."""
+    # Aliases have already been resolved to concrete models by each service.
+    if payload.get("model") not in {
+        "gpt-5.3-codex-spark", "gpt-5.5", "gpt-5.6-luna", "gpt-5.6-terra", "gpt-5.6-sol", "gpt-6-astra",
+    }:
         return payload
     input_items = payload.get("input")
     if not isinstance(input_items, list):
@@ -99,7 +102,7 @@ async def send_upstream_request(
     UpstreamError
         If the HTTP request itself fails (network / timeout).
     """
-    payload = _adapt_astra_system_messages(payload)
+    payload = _adapt_system_messages(payload)
     if verbose:
         log_json("OUTBOUND >> ChatGPT Responses API payload", payload, logger=logger.debug)
 

--- a/tests/test_astra.py
+++ b/tests/test_astra.py
@@ -23,9 +23,17 @@ from gptmock.services.reasoning import (
     allowed_efforts_for_model,
     extract_reasoning_from_model_name,
 )
-from gptmock.services.upstream import _adapt_astra_system_messages
+from gptmock.services.upstream import _adapt_system_messages
 
 ASTRA_EFFORTS = ["low", "medium", "high", "xhigh", "max"]
+SYSTEM_INSTRUCTION_MODELS = [
+    "gpt-5.3-codex-spark", "gpt-5.5", "gpt-5.6-luna", "gpt-5.6-terra", "gpt-5.6-sol", "gpt-6-astra",
+]
+SYSTEM_INSTRUCTION_REQUEST_MODELS = [
+    model + suffix
+    for model in [*SYSTEM_INSTRUCTION_MODELS, "gpt-5.6"]
+    for suffix in (("",) if model == "gpt-5.3-codex-spark" else ("", "-fast"))
+]
 
 
 def test_astra_discovery_and_remote_metadata() -> None:
@@ -100,11 +108,13 @@ def test_astra_rejected_options_are_not_registered() -> None:
 
 
 @pytest.mark.parametrize("route", ["/v1/responses", "/v1/chat/completions", "/api/chat", "/api/generate"])
-@pytest.mark.parametrize("model", ["gpt-6-astra", "gpt-6-astra-fast"])
-def test_astra_system_messages_reach_upstream_as_instructions(
-    monkeypatch: pytest.MonkeyPatch, route: str, model: str,
+@pytest.mark.parametrize("model", SYSTEM_INSTRUCTION_REQUEST_MODELS)
+@pytest.mark.parametrize("stream", [False, True])
+def test_system_messages_reach_upstream_as_instructions(
+    monkeypatch: pytest.MonkeyPatch, route: str, model: str, stream: bool,
 ) -> None:
     captured: list[dict[str, Any]] = []
+    upstream_model, _ = resolve_upstream_model(model)
 
     async def fake_auth() -> tuple[str, str]:
         return "test-token", "test-account"
@@ -113,13 +123,15 @@ def test_astra_system_messages_reach_upstream_as_instructions(
         captured.append(json.loads(request.content))
         event = {"type": "response.completed", "response": {
             "id": "resp_astra",
-            "model": "gpt-6-astra",
+            "model": upstream_model,
             "status": "completed",
             "service_tier": "default",
             "output": [{"type": "message", "role": "assistant", "status": "completed",
                         "content": [{"type": "output_text", "text": "OK", "annotations": []}]}],
         }}
-        return httpx.Response(200, content=f"data: {json.dumps(event)}\n\n".encode())
+        delta = {"type": "response.output_text.delta", "delta": "OK", "output_index": 0, "content_index": 0}
+        events = [delta, event]
+        return httpx.Response(200, content="".join(f"data: {json.dumps(item)}\n\n" for item in events).encode())
 
     async def test_http_client() -> AsyncIterator[httpx.AsyncClient]:
         async with httpx.AsyncClient(transport=httpx.MockTransport(fake_transport)) as client:
@@ -128,7 +140,7 @@ def test_astra_system_messages_reach_upstream_as_instructions(
     for module in ("gptmock.services.chat", "gptmock.services.responses"):
         loaded = importlib.import_module(module)
         monkeypatch.setattr(loaded, "get_effective_chatgpt_auth", fake_auth)
-    payload: dict[str, Any] = {"model": model, "stream": False}
+    payload: dict[str, Any] = {"model": model, "stream": stream}
     if route == "/api/generate":
         payload.update(system="system authority", prompt="hello")
     else:
@@ -143,10 +155,19 @@ def test_astra_system_messages_reach_upstream_as_instructions(
     with TestClient(app) as client:
         response = client.post(route, json=payload)
     assert response.status_code == 200
-    assert response.json()["model"] == "gpt-6-astra"
-    assert response.json()["service_tier"] == "default"
+    if stream:
+        assert "OK" in response.text
+        if route == "/v1/responses":
+            assert "response.completed" in response.text
+        elif route == "/v1/chat/completions":
+            assert "data: [DONE]" in response.text
+        else:
+            assert json.loads(response.text.splitlines()[-1])["done"] is True
+    else:
+        assert response.json()["model"] == upstream_model
+        assert response.json()["service_tier"] == "default"
     assert len(captured) == 1
-    assert captured[0]["model"] == "gpt-6-astra"
+    assert captured[0]["model"] == upstream_model
     assert captured[0]["instructions"].endswith("system authority")
     expected_roles = ["user"] if route == "/api/generate" else ["developer", "user"]
     assert [item["role"] for item in captured[0]["input"]] == expected_roles
@@ -154,27 +175,43 @@ def test_astra_system_messages_reach_upstream_as_instructions(
         assert captured[0]["service_tier"] == "priority"
 
 
-def test_astra_instruction_adaptation_preserves_text_and_input_payload() -> None:
+@pytest.mark.parametrize("model", SYSTEM_INSTRUCTION_MODELS)
+def test_instruction_adaptation_preserves_text_and_input_payload(model: str) -> None:
     payload = {
-        "model": "gpt-6-astra", "instructions": "existing instructions",
+        "model": model, "instructions": "existing instructions",
+        "reasoning": {"effort": "low"}, "service_tier": "priority",
+        "tools": [{"type": "function", "name": "lookup", "strict": True,
+                   "parameters": {"type": "object", "properties": {}, "additionalProperties": False}}],
+        "tool_choice": "required",
         "input": [
             {"role": "system", "content": "first system"},
             {"type": "message", "role": "system", "content": [{"type": "input_text", "text": "second system"}]},
+            {"role": "developer", "content": "developer authority"},
             {"role": "user", "content": "hello"},
+            {"type": "function_call", "call_id": "call_1", "name": "lookup", "arguments": "{}"},
+            {"type": "function_call_output", "call_id": "call_1", "output": "lookup result"},
         ],
     }
-    adapted = _adapt_astra_system_messages(payload)
+    original = json.loads(json.dumps(payload))
+    adapted = _adapt_system_messages(payload)
     assert adapted["instructions"] == "existing instructions\n\nfirst system\n\nsecond system"
-    assert adapted["input"] == [{"role": "user", "content": "hello"}]
-    assert payload["instructions"] == "existing instructions"
-    assert len(payload["input"]) == 3
-    assert _adapt_astra_system_messages(adapted) == adapted
+    assert adapted["input"] == original["input"][2:]
+    for key in ("model", "reasoning", "service_tier", "tools", "tool_choice"):
+        assert adapted[key] == original[key]
+    assert payload == original
+    assert _adapt_system_messages(adapted) == adapted
 
 
-def test_astra_instruction_adaptation_does_not_discard_nontext_content() -> None:
-    payload = {"model": "gpt-6-astra", "input": [
+@pytest.mark.parametrize("model", SYSTEM_INSTRUCTION_MODELS)
+def test_instruction_adaptation_does_not_discard_nontext_content(model: str) -> None:
+    payload = {"model": model, "input": [
+        {"role": "system", "content": "preserve this text too"},
         {"role": "system", "content": [{"type": "input_image", "image_url": "https://example.com/image.png"}]},
     ]}
-    assert _adapt_astra_system_messages(payload) is payload
-    other_model = {"model": "gpt-5.6-luna", "input": [{"role": "system", "content": "system authority"}]}
-    assert _adapt_astra_system_messages(other_model) is other_model
+    assert _adapt_system_messages(payload) is payload
+
+
+@pytest.mark.parametrize("model", ["gpt-5.4", "gpt-5.4-mini", "unknown-model"])
+def test_instruction_adaptation_leaves_other_models_unchanged(model: str) -> None:
+    payload = {"model": model, "input": [{"role": "system", "content": "system authority"}]}
+    assert _adapt_system_messages(payload) is payload

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -107,7 +107,7 @@ class TestAppBootstrap:
         assert len(data["models"]) > 0
 
     def test_ollama_show_valid_model(self, client: TestClient) -> None:
-        resp = client.post("/api/show", json={"model": "gpt-5.4"})
+        resp = client.post("/api/show", json={"model": "gpt-5.5"})
         assert resp.status_code == 200
         data = resp.json()
         assert "details" in data
@@ -364,8 +364,8 @@ class TestModelRegistry:
     def test_get_openai_models_reasoning_per_family(self) -> None:
         models = {m["id"]: m for m in get_openai_models(expose_reasoning=False)}
 
-        assert "xhigh" in models["gpt-5.4"]["reasoning"]["supported_efforts"]
-        assert "minimal" not in models["gpt-5.4"]["reasoning"]["supported_efforts"]
+        assert "xhigh" in models["gpt-5.5"]["reasoning"]["supported_efforts"]
+        assert "minimal" not in models["gpt-5.5"]["reasoning"]["supported_efforts"]
         assert models["gpt-5.6-luna"]["reasoning"]["supported_efforts"] == [
             "none", "low", "medium", "high", "xhigh", "max",
         ]
@@ -373,23 +373,23 @@ class TestModelRegistry:
     def test_get_openai_models_reasoning_for_variants(self) -> None:
         models = {m["id"]: m for m in get_openai_models(expose_reasoning=True)}
 
-        gpt54_high = models["gpt-5.4-high"]["reasoning"]
-        assert gpt54_high["supported_efforts"] == ["low", "medium", "high", "xhigh"]
-        assert gpt54_high["preset_effort"] == "high"
+        gpt55_high = models["gpt-5.5-high"]["reasoning"]
+        assert gpt55_high["supported_efforts"] == ["low", "medium", "high", "xhigh"]
+        assert gpt55_high["preset_effort"] == "high"
 
-        gpt54_xhigh = models["gpt-5.4-xhigh"]["reasoning"]
-        assert gpt54_xhigh["supported_efforts"] == ["low", "medium", "high", "xhigh"]
-        assert gpt54_xhigh["preset_effort"] == "xhigh"
+        gpt55_xhigh = models["gpt-5.5-xhigh"]["reasoning"]
+        assert gpt55_xhigh["supported_efforts"] == ["low", "medium", "high", "xhigh"]
+        assert gpt55_xhigh["preset_effort"] == "xhigh"
 
     def test_get_openai_models_default_effort_reflects_setting(self) -> None:
         models_medium = {m["id"]: m for m in get_openai_models(default_effort="medium")}
-        assert models_medium["gpt-5.4"]["reasoning"]["default_effort"] == "medium"
+        assert models_medium["gpt-5.5"]["reasoning"]["default_effort"] == "medium"
 
         models_high = {m["id"]: m for m in get_openai_models(default_effort="high")}
-        assert models_high["gpt-5.4"]["reasoning"]["default_effort"] == "high"
+        assert models_high["gpt-5.5"]["reasoning"]["default_effort"] == "high"
 
         models_xhigh = {m["id"]: m for m in get_openai_models(default_effort="xhigh")}
-        assert models_xhigh["gpt-5.4"]["reasoning"]["default_effort"] == "xhigh"
+        assert models_xhigh["gpt-5.5"]["reasoning"]["default_effort"] == "xhigh"
 
     def test_get_openai_models_endpoint_reflects_configured_default_effort(
         self, client: TestClient
@@ -398,7 +398,7 @@ class TestModelRegistry:
         assert resp.status_code == 200
         data = resp.json()
         models = {m["id"]: m for m in data["data"]}
-        assert models["gpt-5.4"]["reasoning"]["default_effort"] in {
+        assert models["gpt-5.5"]["reasoning"]["default_effort"] in {
             "low", "medium", "high", "xhigh",
         }
 
@@ -414,9 +414,10 @@ class TestModelRegistry:
     def test_variant_detection_requires_known_base(self) -> None:
         from gptmock.services.model_registry import _detect_preset_effort
 
-        assert _detect_preset_effort("gpt-5.4-high") == "high"
-        assert _detect_preset_effort("gpt-5.4_medium") == "medium"
-        assert _detect_preset_effort("gpt-5.4") is None
+        assert _detect_preset_effort("gpt-5.5-high") == "high"
+        assert _detect_preset_effort("gpt-5.5_medium") == "medium"
+        assert _detect_preset_effort("gpt-5.5") is None
+        assert _detect_preset_effort("gpt-5.4-high") is None
         assert _detect_preset_effort("unknown-model-high") is None
 
     def test_allowed_efforts_handles_variant_ids(self) -> None:
@@ -481,9 +482,6 @@ class TestFastModelVariants:
             assert models[f"gpt-5.6-{family}"]["reasoning"]["supported_efforts"] == gpt56_efforts
 
     def test_normalize_fast_aliases(self) -> None:
-        assert normalize_model_name("gpt-5.4-fast") == "gpt-5.4-fast"
-        assert normalize_model_name("gpt5.4-fast") == "gpt-5.4-fast"
-        assert normalize_model_name("gpt-5.4-fast-latest") == "gpt-5.4-fast"
         assert normalize_model_name("gpt-5.5") == "gpt-5.5"
         assert normalize_model_name("gpt5.5") == "gpt-5.5"
         assert normalize_model_name("gpt-5.5-latest") == "gpt-5.5"
@@ -504,31 +502,22 @@ class TestFastModelVariants:
             assert normalize_model_name(f"gpt-5.6-{family}-fast") == f"gpt-5.6-{family}-fast"
             assert normalize_model_name(f"gpt5.6-{family}-fast") == f"gpt-5.6-{family}-fast"
             assert normalize_model_name(f"gpt-5.6-{family}-fast-latest") == f"gpt-5.6-{family}-fast"
-        assert normalize_model_name("gpt-5.4-mini-fast") == "gpt-5.4-mini-fast"
-        assert normalize_model_name("gpt5.4-mini-fast") == "gpt-5.4-mini-fast"
-        assert normalize_model_name("gpt-5.4-mini-fast-latest") == "gpt-5.4-mini-fast"
 
     def test_normalize_fast_with_effort_suffix_strips_effort(self) -> None:
-        assert normalize_model_name("gpt-5.4-fast-medium") == "gpt-5.4-fast"
-        assert normalize_model_name("gpt-5.4-fast-xhigh") == "gpt-5.4-fast"
         assert normalize_model_name("gpt-5.5-fast-medium") == "gpt-5.5-fast"
         assert normalize_model_name("gpt-5.5-fast-xhigh") == "gpt-5.5-fast"
         assert normalize_model_name("gpt-5.6-sol-fast-medium") == "gpt-5.6-sol-fast"
         assert normalize_model_name("gpt-5.6-sol-fast-xhigh") == "gpt-5.6-sol-fast"
-        assert normalize_model_name("gpt-5.4-mini-fast-high") == "gpt-5.4-mini-fast"
-        assert normalize_model_name("gpt-5.4-mini-fast-low") == "gpt-5.4-mini-fast"
 
     def test_resolve_upstream_model_for_fast_aliases(self) -> None:
         from gptmock.services.model_registry import resolve_upstream_model
 
         priority = {"service_tier": "priority"}
-        assert resolve_upstream_model("gpt-5.4-fast") == ("gpt-5.4", priority)
         assert resolve_upstream_model("gpt-5.5-fast") == ("gpt-5.5", priority)
         assert resolve_upstream_model("gpt-5.6-fast") == ("gpt-5.6-sol", priority)
         assert resolve_upstream_model("gpt-5.6-sol-fast") == ("gpt-5.6-sol", priority)
         assert resolve_upstream_model("gpt-5.6-terra-fast") == ("gpt-5.6-terra", priority)
         assert resolve_upstream_model("gpt-5.6-luna-fast") == ("gpt-5.6-luna", priority)
-        assert resolve_upstream_model("gpt-5.4-mini-fast") == ("gpt-5.4-mini", priority)
 
     def test_apply_model_overrides_sets_service_tier(self) -> None:
         payload = {"service_tier": "default"}

--- a/tests/test_image_generation_probe.py
+++ b/tests/test_image_generation_probe.py
@@ -14,8 +14,11 @@ from starlette.testclient import TestClient
     reason="Live image generation is opt-in because it consumes ChatGPT/Codex credits.",
 )
 def test_responses_image_generation_live(client: TestClient, tmp_path: Path) -> None:
+    model = os.getenv("GPTMOCK_IMAGE_GENERATION_MODEL", "").strip()
+    if not model:
+        pytest.skip("Set GPTMOCK_IMAGE_GENERATION_MODEL to an account-verified image-generation model.")
     payload: dict[str, Any] = {
-        "model": os.getenv("GPTMOCK_IMAGE_GENERATION_MODEL", "gpt-5.4-mini"),
+        "model": model,
         "input": [
             {
                 "type": "message",

--- a/tests/test_ollama_client.py
+++ b/tests/test_ollama_client.py
@@ -35,7 +35,7 @@ def test_ollama_tags(client: TestClient) -> None:
 
 def test_ollama_show(client: TestClient) -> None:
     """POST /api/show returns model details."""
-    payload = {"model": "gpt-5.4"}
+    payload = {"model": "gpt-5.5"}
     resp = client.post("/api/show", json=payload, timeout=TIMEOUT)
     assert resp.status_code == 200
     data = resp.json()

--- a/tests/test_retired_models.py
+++ b/tests/test_retired_models.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import importlib
+import json
+from collections.abc import AsyncIterator
+
+import httpx
+import pytest
+from starlette.testclient import TestClient
+
+from gptmock.app import create_app
+from gptmock.core.dependencies import get_http_client
+from gptmock.core.settings import Settings
+from gptmock.services.model_registry import (
+    FAST_MODEL_ALIASES,
+    MODEL_GROUPS,
+    SYNTHETIC_MODEL_GROUPS,
+    normalize_model_name,
+    resolve_upstream_model,
+)
+
+RETIRED_MODELS = ("gpt-5.4", "gpt-5.4-mini", "gpt-5.4-fast", "gpt-5.4-mini-fast")
+GENERATION_ROUTES = (
+    "/v1/chat/completions", "/v1/completions", "/v1/responses", "/api/chat", "/api/generate",
+)
+
+
+@pytest.mark.parametrize("expose_reasoning", [False, True])
+def test_retired_models_are_absent_from_discovery(expose_reasoning: bool) -> None:
+    with TestClient(create_app(Settings(expose_reasoning_models=expose_reasoning))) as client:
+        models = client.get("/v1/models")
+        tags = client.get("/api/tags")
+        assert models.status_code == tags.status_code == 200
+        model_ids = {item["id"] for item in models.json()["data"]}
+        tag_ids = {item["name"] for item in tags.json()["models"]}
+        assert model_ids == tag_ids
+        assert "gpt-5.5" in model_ids
+        assert not any(name.startswith("gpt-5.4") for name in model_ids)
+        for model in RETIRED_MODELS:
+            assert client.post("/api/show", json={"model": model}).status_code == 404
+            assert client.post("/api/show", json={"name": model}).status_code == 404
+        if expose_reasoning:
+            assert client.post("/api/show", json={"model": "gpt-5.4-high"}).status_code == 404
+
+
+@pytest.mark.parametrize("model", RETIRED_MODELS)
+def test_retired_models_have_no_registered_alias_or_substitution(model: str) -> None:
+    assert model not in {name for name, _ in (*MODEL_GROUPS, *SYNTHETIC_MODEL_GROUPS)}
+    assert model not in FAST_MODEL_ALIASES
+    assert normalize_model_name(model) == model
+    assert resolve_upstream_model(model) == (model, {})
+
+
+@pytest.mark.parametrize("model", RETIRED_MODELS)
+@pytest.mark.parametrize("route", GENERATION_ROUTES)
+@pytest.mark.parametrize("stream", [False, True])
+def test_explicit_retired_requests_preserve_upstream_rejection(
+    monkeypatch: pytest.MonkeyPatch, model: str, route: str, stream: bool,
+) -> None:
+    captured: list[dict] = []
+
+    async def fake_auth() -> tuple[str, str]:
+        return "test-token", "test-account"
+
+    def fake_transport(request: httpx.Request) -> httpx.Response:
+        captured.append(json.loads(request.content))
+        return httpx.Response(400, json={"error": {"message": "retired-model-probe-rejected"}})
+
+    async def test_http_client() -> AsyncIterator[httpx.AsyncClient]:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(fake_transport)) as client:
+            yield client
+
+    for module in ("gptmock.services.chat", "gptmock.services.responses"):
+        monkeypatch.setattr(importlib.import_module(module), "get_effective_chatgpt_auth", fake_auth)
+    app = create_app(Settings(debug_model=None))
+    app.dependency_overrides[get_http_client] = test_http_client
+    payload = {"model": model, "stream": stream, "messages": [{"role": "user", "content": "hello"}],
+               "prompt": "hello", "input": "hello"}
+    with TestClient(app) as client:
+        response = client.post(route, json=payload)
+    assert response.status_code == 400
+    assert "retired-model-probe-rejected" in response.text
+    assert len(captured) == 1
+    assert captured[0]["model"] == model
+    assert captured[0].get("service_tier") != "priority"
+
+
+@pytest.mark.parametrize("model", [None, "", " ", "\t\n"])
+def test_empty_model_has_no_implicit_default(model: str | None) -> None:
+    with pytest.raises(ValueError, match="non-empty model"):
+        normalize_model_name(model)
+
+
+def test_explicit_debug_model_override_remains_available() -> None:
+    assert normalize_model_name("", debug_model="gpt-5.5") == "gpt-5.5"
+
+
+@pytest.mark.parametrize("route", GENERATION_ROUTES)
+@pytest.mark.parametrize("model", ["", " \t\n"])
+@pytest.mark.parametrize("stream", [False, True])
+def test_empty_model_fails_before_authentication(
+    monkeypatch: pytest.MonkeyPatch, route: str, model: str, stream: bool,
+) -> None:
+    async def unexpected_auth() -> tuple[str, str]:
+        pytest.fail("An empty model must not authenticate or call upstream")
+
+    for module in ("gptmock.services.chat", "gptmock.services.responses"):
+        monkeypatch.setattr(importlib.import_module(module), "get_effective_chatgpt_auth", unexpected_auth)
+    payload = {"model": model, "stream": stream, "messages": [{"role": "user", "content": "hello"}],
+               "prompt": "hello", "input": "hello"}
+    with TestClient(create_app(Settings(debug_model=None))) as client:
+        response = client.post(route, json=payload)
+    assert response.status_code == 400
+    assert "non-empty model" in response.text
+
+
+@pytest.mark.parametrize("route", GENERATION_ROUTES)
+def test_missing_model_remains_a_validation_error(route: str) -> None:
+    with TestClient(create_app(Settings(debug_model=None))) as client:
+        response = client.post(route, json={"messages": [], "prompt": "hello", "input": "hello"})
+    assert response.status_code == 422


### PR DESCRIPTION
> **Note to the maintainer:** I'm sorry I didn't review my previous PR thoroughly enough before submitting it. That left compatibility issues and inaccurate documentation for you to deal with. Thank you for your time and patience. This follow-up addresses the issues identified since then and clearly distinguishes verified results from remaining limitations.

## Summary

Follow-up to #20: fix `System messages are not allowed` for GPT-5.5, GPT-5.6 Luna/Terra/Sol, and GPT-5.3 Codex Spark by extending the existing Astra system-message adapter.

Text system messages are carried into upstream Responses `instructions`, after existing instructions and in message order. Clients can keep their system prompts without changing models or discarding instructions.

Also remove GPT-5.4/mini from model discovery following their rejection by the tested ChatGPT Codex backend.

## Routing

Active models keep their identities. Existing aliases are resolved before system-message adaptation, and Astra retains its existing behavior.

GPT-5.4/mini and their effort variants are removed from discovery, and their fast aliases are unregistered. Explicit retired-model requests are not substituted with another model; upstream rejection remains visible.

No Spark fast alias is added.

## Changes

- Extend the system-message adapter to GPT-5.5, GPT-5.6 Luna/Terra/Sol, and Spark.
- Preserve developer/user messages, tool-call history, strict schemas, and required tool choice.
- Keep other models and unsupported non-text system content unchanged.
- Remove GPT-5.4/mini from `/v1/models` and `/api/tags`; return 404 for their `/api/show` requests.
- Reject empty model names before upstream authentication instead of implicitly choosing GPT-5.4.
- Require an explicitly selected model for the opt-in image-generation test.
- Update README troubleshooting, dated availability results, Docker rebuild guidance, and image examples.
- Remove instructions for the absent `probe_image_generation.py` script.
- Restore upstream-style RayBytes/rapidrabbit76 credits and remove contribution-fork branding. Preserve LICENSE, package metadata, and the original `docker-compose.yml`.

## Testing

Local validation on 2026-09-13:

- Full suite via `pytest.main`, using `tests/ --no-testmon -q`: **520 passed, 90 skipped**.
- `ruff check gptmock/ tests/ --no-cache`: passed.
- `git diff --check`: passed.
- **104 simulated-upstream cases** cover four API routes, existing aliases, and streaming/non-streaming requests.
- **76 additional regression cases** cover retired-model discovery, alias removal, rejection without substitution, and empty/missing models.

Retiring two models removes 24 model-parameterized opt-in cases; the lower skip count is not additional live coverage.

Docker deployment validation on 2026-09-13:

- Rebuilt and recreated GPTMock; container running/healthy.
- Direct Chat requests passed **6/6 checks**: GPT-5.5, GPT-5.5-fast, and Spark, each streaming and non-streaming.
- All six preserved the expected concrete model and returned the expected system/developer/user test marker without system-role errors.

The local results include the registry/default cleanup. The Docker results cover the preceding system-message patch, before that cleanup.

## Notes

- Live results are specific to the tested ChatGPT Codex backend/account.
- One earlier Spark streaming probe did not exactly match the requested text; follow-up and deployed checks matched.
- The final patch was not revalidated end-to-end through Hermes, OpenCode, or a native Ollama client.
- Simulated-upstream tests and skipped tests are not claimed as live verification.
- Image generation was not revalidated with a replacement model.
- The registry/default cleanup has local regression coverage but has not yet been deployed.
- No gateway configuration changes, credentials, private deployment addresses, or raw client sessions are included.
